### PR TITLE
remove the camel:run maven goal

### DIFF
--- a/fcrepo-audit-triplestore/README.md
+++ b/fcrepo-audit-triplestore/README.md
@@ -12,12 +12,6 @@ To build this project use
 
     mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using

--- a/fcrepo-audit-triplestore/pom.xml
+++ b/fcrepo-audit-triplestore/pom.xml
@@ -136,11 +136,6 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>

--- a/fcrepo-fixity/README.md
+++ b/fcrepo-fixity/README.md
@@ -21,12 +21,6 @@ To build this project use
 
     MAVEN_OPTS="-Xmx1024m" mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using

--- a/fcrepo-fixity/pom.xml
+++ b/fcrepo-fixity/pom.xml
@@ -111,12 +111,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
-
       <!-- reserve network ports for integration testing -->
       <!-- add configuration file to artifact set for OSGi deployment -->
       <plugin>

--- a/fcrepo-indexing-solr/README.md
+++ b/fcrepo-indexing-solr/README.md
@@ -27,12 +27,6 @@ To build this project use
 
     MAVEN_OPTS="-Xmx1024m" mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using

--- a/fcrepo-indexing-solr/pom.xml
+++ b/fcrepo-indexing-solr/pom.xml
@@ -229,12 +229,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
-
       <!-- reserve network ports for integration testing -->
       <!-- add configuration file to artifact set for OSGi deployment -->
       <plugin>

--- a/fcrepo-indexing-triplestore/README.md
+++ b/fcrepo-indexing-triplestore/README.md
@@ -12,12 +12,6 @@ To build this project use
 
     MAVEN_OPTS="-Xmx1024m" mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -114,12 +114,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
-
       <!-- enable checkstyle plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/fcrepo-reindexing/README.md
+++ b/fcrepo-reindexing/README.md
@@ -14,12 +14,6 @@ To build this project use
 
     MAVEN_OPTS="-Xmx1024m" mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using

--- a/fcrepo-reindexing/pom.xml
+++ b/fcrepo-reindexing/pom.xml
@@ -103,12 +103,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
-
       <!-- enable checkstyle plugin -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/fcrepo-serialization/README.md
+++ b/fcrepo-serialization/README.md
@@ -10,12 +10,6 @@ To build this project use
 
     MAVEN_OPTS="-Xmx1024m" mvn install
 
-##Running from the command line
-
-To run the project you can execute the following Maven goal
-
-    mvn camel:run
-
 ##Deploying in OSGi
 
 This project can be deployed in an OSGi container. For example using 

--- a/fcrepo-serialization/pom.xml
+++ b/fcrepo-serialization/pom.xml
@@ -137,12 +137,6 @@
         <artifactId>maven-bundle-plugin</artifactId>
       </plugin>
 
-       <!-- to run the example using mvn camel:run -->
-      <plugin>
-        <groupId>org.apache.camel</groupId>
-        <artifactId>camel-maven-plugin</artifactId>
-      </plugin>
-
       <!-- reserve network ports for integration testing -->
       <!-- add configuration file to artifact set for OSGi deployment -->
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -361,16 +361,6 @@
     <pluginManagement>
       <plugins>
 
-        <!-- to run the example using mvn camel:run -->
-        <plugin>
-          <groupId>org.apache.camel</groupId>
-          <artifactId>camel-maven-plugin</artifactId>
-          <version>${camel.version}</version>
-          <configuration>
-            <useBlueprint>true</useBlueprint>
-          </configuration>
-        </plugin>
-
         <!-- reserve network ports for integration testing -->
         <plugin>
           <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The `mvn camel:run` goal is not very useful for users experimenting with `fcrepo-camel-toolbox`. This removes the references to in the documentation and from the maven configuration.