### PR TITLE
Fix broken reindexing

### DIFF
--- a/fcrepo-fixity/src/main/java/org/fcrepo/camel/fixity/FixityRouter.java
+++ b/fcrepo-fixity/src/main/java/org/fcrepo/camel/fixity/FixityRouter.java
@@ -53,14 +53,14 @@ public class FixityRouter extends RouteBuilder {
          */
         from("{{fixity.stream}}")
             .routeId("FcrepoFixity")
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManged")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManged&accept=application/rdf+xml")
             .filter().xpath(
                     "/rdf:RDF/rdf:Description/rdf:type" +
                     "[@rdf:resource='" + RdfNamespaces.REPOSITORY + "Binary']", ns)
             .log(LoggingLevel.INFO, LOGGER,
                     "Checking Fixity for ${headers[CamelFcrepoIdentifier]}")
             .delay(simple("{{fixity.delay}}"))
-            .to("fcrepo:{{fcrepo.baseUrl}}?fixity=true")
+            .to("fcrepo:{{fcrepo.baseUrl}}?fixity=true&accept=application/rdf+xml")
             .choice()
                 .when().xpath(
                         "/rdf:RDF/rdf:Description/premis:hasEventOutcome" +

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
@@ -94,7 +94,7 @@ public class SolrRouter extends RouteBuilder {
             .removeHeaders("CamelHttp*")
             .filter(not(or(header(IDENTIFIER).startsWith(simple("{{audit.container}}/")),
                     header(IDENTIFIER).isEqualTo(simple("{{audit.container}}")))))
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferOmit=PreferContainment")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferOmit=PreferContainment&accept=application/rdf+xml")
             .setHeader(FCREPO_TRANSFORM).xpath(hasIndexingTransformation, String.class, ns)
             .removeHeaders("CamelHttp*")
             .choice()

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
@@ -88,7 +88,7 @@ public class TriplestoreRouter extends RouteBuilder {
             .filter(not(or(header(IDENTIFIER).startsWith(simple("{{audit.container}}/")),
                     header(IDENTIFIER).isEqualTo(simple("{{audit.container}}")))))
             .removeHeaders("CamelHttp*")
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer&accept=application/rdf+xml")
             .choice()
                 .when(or(simple("{{indexing.predicate}} != 'true'"), indexable))
                     .to("direct:update.triplestore")

--- a/fcrepo-reindexing/README.md
+++ b/fcrepo-reindexing/README.md
@@ -53,6 +53,10 @@ The camel URI for the internal reindexing queue.
 
     reindexing.stream=activemq:queue:reindexing
 
+The host to which to bind the HTTP endpoint
+
+    rest.host=localhost
+
 The port at which reindexing requests can be sent.
 
     rest.port=9080

--- a/fcrepo-reindexing/src/main/cfg/org.fcrepo.camel.reindexing.cfg
+++ b/fcrepo-reindexing/src/main/cfg/org.fcrepo.camel.reindexing.cfg
@@ -20,3 +20,6 @@ rest.prefix=/reindexing
 
 # The port at which reindexing requests can be sent.
 rest.port=9080
+
+# The hostname that the servlet component binds to
+rest.host=localhost

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
@@ -50,6 +50,8 @@ public class ReindexingRouter extends RouteBuilder {
      */
     public void configure() throws Exception {
 
+        final String hostname = host.startsWith("http") ? host : "http://" + host;
+
         final Namespaces ns = new Namespaces("rdf", RdfNamespaces.RDF);
         ns.add("ldp", RdfNamespaces.LDP);
 
@@ -63,7 +65,6 @@ public class ReindexingRouter extends RouteBuilder {
         /**
          * Expose a RESTful endpoint for re-indexing
          */
-        final String hostname = host.startsWith("http") ? host : "http://" + host;
         from("jetty:" + hostname + ":" + port + "{{rest.prefix}}?matchOnUriPrefix=true&httpMethodRestrict=GET,POST")
             .routeId("FcrepoReindexingRest")
             .routeDescription("Expose the reindexing endpoint over HTTP")
@@ -76,7 +77,7 @@ public class ReindexingRouter extends RouteBuilder {
         from("direct:usage")
             .routeId("FcrepoReindexingUsage")
             .setHeader(ReindexingHeaders.REST_PREFIX).simple("{{rest.prefix}}")
-            .setHeader(ReindexingHeaders.REST_PORT).simple("{{rest.port}}")
+            .setHeader(ReindexingHeaders.REST_PORT).simple(port)
             .setHeader(FCREPO_BASE_URL).simple("{{fcrepo.baseUrl}}")
             .process(new UsageProcessor());
 

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
@@ -42,13 +42,13 @@ public class ReindexingRouter extends RouteBuilder {
     @PropertyInject(value = "rest.port", defaultValue = "9080")
     private String port;
 
+    @PropertyInject(value = "rest.host", defaultValue = "localhost")
+    private String host;
+
     /**
      * Configure the message route workflow.
      */
     public void configure() throws Exception {
-
-        restConfiguration().component("jetty").port(
-                System.getProperty("fcrepo.dynamic.reindexing.port", port));
 
         final Namespaces ns = new Namespaces("rdf", RdfNamespaces.RDF);
         ns.add("ldp", RdfNamespaces.LDP);
@@ -63,9 +63,15 @@ public class ReindexingRouter extends RouteBuilder {
         /**
          * Expose a RESTful endpoint for re-indexing
          */
-        rest("{{rest.prefix}}")
-            .get().to("direct:usage")
-            .post().consumes("application/json").to("direct:reindex");
+        final String hostname = host.startsWith("http") ? host : "http://" + host;
+        from("jetty:" + hostname + ":" + port + "{{rest.prefix}}?matchOnUriPrefix=true&httpMethodRestrict=GET,POST")
+            .routeId("FcrepoReindexingRest")
+            .routeDescription("Expose the reindexing endpoint over HTTP")
+            .choice()
+                .when(header(Exchange.HTTP_METHOD).isEqualTo("GET"))
+                    .to("direct:usage")
+                .otherwise()
+                    .to("direct:reindex");
 
         from("direct:usage")
             .routeId("FcrepoReindexingUsage")
@@ -104,7 +110,8 @@ public class ReindexingRouter extends RouteBuilder {
             .inOnly("direct:recipients")
             .removeHeaders("CamelHttp*")
             .setHeader(Exchange.HTTP_METHOD).constant(HttpMethods.GET)
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferContainment&preferOmit=ServerManaged")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferContainment" +
+                    "&preferOmit=ServerManaged&accept=application/rdf+xml")
             .convertBodyTo(StreamSource.class)
             .split().xtokenize("/rdf:RDF/rdf:Description/ldp:contains", 'i', ns).streaming()
                 .transform().xpath("/ldp:contains/@rdf:resource", String.class, ns)

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/RestProcessor.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/RestProcessor.java
@@ -17,7 +17,6 @@ package org.fcrepo.camel.reindexing;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.net.URL;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -56,8 +55,7 @@ public class RestProcessor implements Processor {
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
 
-        final URL url = new URL(in.getHeader(Exchange.HTTP_URI, String.class));
-        final String prefix = in.getHeader(ReindexingHeaders.REST_PREFIX, "", String.class);
+        final String path = in.getHeader(Exchange.HTTP_PATH, "", String.class);
         final String contentType = in.getHeader(Exchange.CONTENT_TYPE, "", String.class);
         final String body = in.getBody(String.class);
         final Set<String> endpoints = new HashSet<>();
@@ -67,8 +65,6 @@ public class RestProcessor implements Processor {
         }
 
         in.removeHeaders("CamelHttp*");
-        in.removeHeaders("CamelRestlet*");
-        in.removeHeaders("org.restlet*");
         in.removeHeader("JMSCorrelationID");
         in.setBody(null);
 
@@ -88,7 +84,7 @@ public class RestProcessor implements Processor {
             }
         }
 
-        in.setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, url.getPath().substring(prefix.length()));
+        in.setHeader(FcrepoHeaders.FCREPO_IDENTIFIER, path);
         in.setHeader(ReindexingHeaders.RECIPIENTS, String.join(",", endpoints));
     }
 }

--- a/fcrepo-reindexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-reindexing/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,6 +18,7 @@
        <cm:property name="reindexing.stream" value="activemq:queue:reindexing"/>
        <cm:property name="jms.brokerUrl" value="tcp://localhost:61616"/>
        <cm:property name="rest.prefix" value="/reindexing"/>
+       <cm:property name="rest.host" value="localhost"/>
        <cm:property name="rest.port" value="9080"/>
      </cm:default-properties>
    </cm:property-placeholder>

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RestProcessorTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RestProcessorTest.java
@@ -38,9 +38,6 @@ import org.junit.Test;
  */
 public class RestProcessorTest extends CamelTestSupport {
 
-    final static String restPrefix = "/camel-indexing";
-    final static String baseUrl = "http://localhost";
-
     @EndpointInject(uri = "mock:result")
     protected MockEndpoint resultEndpoint;
 
@@ -59,20 +56,17 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(2).header(ReindexingHeaders.RECIPIENTS).isEqualTo("");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/");
+        headers.put(Exchange.HTTP_PATH, "/");
         template.sendBodyAndHeaders("", headers);
 
         headers.clear();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS,
                 "activemq:queue:foo, activemq:queue:bar,\t\nactivemq:queue:foo   ");
         template.sendBodyAndHeaders("", headers);
 
         headers.clear();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS, null);
         template.sendBodyAndHeaders("", headers);
 
@@ -88,9 +82,8 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).contains("activemq:queue:foo");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
         headers.put(Exchange.CONTENT_TYPE, "application/json");
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         template.sendBodyAndHeaders(body, headers);
 
         assertMockEndpointsSatisfied();
@@ -106,8 +99,7 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).contains("activemq:queue:baz");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(Exchange.CONTENT_TYPE, "application/json");
         headers.put(ReindexingHeaders.RECIPIENTS, "activemq:queue:baz");
         template.sendBodyAndHeaders(body, headers);
@@ -122,9 +114,8 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).isEqualTo("activemq:queue:baz");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
         headers.put(Exchange.CONTENT_TYPE, "application/json");
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS, "activemq:queue:baz");
         template.sendBodyAndHeaders(null, headers);
 
@@ -140,8 +131,7 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).isEqualTo("activemq:queue:baz");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS, "activemq:queue:baz");
         template.sendBodyAndHeaders(body, headers);
 
@@ -157,9 +147,8 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).isEqualTo("activemq:queue:baz");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
         headers.put(Exchange.CONTENT_TYPE, "application/foo");
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS, "activemq:queue:baz");
         template.sendBodyAndHeaders(body, headers);
 
@@ -174,9 +163,8 @@ public class RestProcessorTest extends CamelTestSupport {
         resultEndpoint.message(0).header(ReindexingHeaders.RECIPIENTS).isEqualTo("activemq:queue:baz");
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(ReindexingHeaders.REST_PREFIX, restPrefix);
         headers.put(Exchange.CONTENT_TYPE, "application/json");
-        headers.put(Exchange.HTTP_URI, baseUrl + restPrefix + "/foo/bar");
+        headers.put(Exchange.HTTP_PATH, "/foo/bar");
         headers.put(ReindexingHeaders.RECIPIENTS, "activemq:queue:baz");
         template.sendBodyAndHeaders("    ", headers);
 

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
@@ -140,7 +140,7 @@ public class RouteTest extends CamelBlueprintTestSupport {
 
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(Exchange.HTTP_URI, "http://localhost" + restPrefix + id);
+        headers.put(Exchange.HTTP_PATH, id);
         headers.put(ReindexingHeaders.RECIPIENTS, "");
 
         template.sendBodyAndHeaders("direct:reindex", null, headers);
@@ -175,7 +175,7 @@ public class RouteTest extends CamelBlueprintTestSupport {
         getMockEndpoint("mock:result").expectedBodiesReceived("Indexing started at " + id);
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(Exchange.HTTP_URI, "http://localhost" + restPrefix + id);
+        headers.put(Exchange.HTTP_PATH, id);
         headers.put(ReindexingHeaders.RECIPIENTS, "mock:endpoint");
 
         template.sendBodyAndHeaders("direct:reindex", null, headers);

--- a/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
+++ b/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
@@ -95,10 +95,10 @@ public class SerializationRouter extends RouteBuilder {
         from("direct:binary")
             .routeId("FcrepoSerializationBinaryUpdater")
             .filter().simple("{{serialization.includeBinaries}} == 'true'")
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer" +
+                    "&accept=application/rdf+xml")
             .filter().xpath(isBinaryResourceXPath, ns)
-            .log(INFO, LOGGER,
-                    "Writing binary ${headers[CamelFcrepoIdentifier]}")
+            .log(INFO, LOGGER, "Writing binary ${headers[CamelFcrepoIdentifier]}")
             .to("fcrepo:{{fcrepo.baseUrl}}?metadata=false")
             .setHeader(FILE_NAME).header(FCREPO_IDENTIFIER)
             .log(DEBUG, LOGGER, "header filename is: ${headers[CamelFileName]}")

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.18</grizzly.version>
     <hamcrest.version>1.3</hamcrest.version>
+    <httpclient.version>4.3.6</httpclient.version>
     <hk2.version>2.3.0</hk2.version>
     <jena.fuseki.version>1.1.1</jena.fuseki.version>
     <jersey.version>2.15</jersey.version>
@@ -236,6 +237,13 @@
         <groupId>org.apache.camel</groupId>
         <artifactId>camel-test-blueprint</artifactId>
         <version>${camel.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>${httpclient.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/toolbox-features/pom.xml
+++ b/toolbox-features/pom.xml
@@ -183,6 +183,10 @@
             <portName>fcrepo.dynamic.test.port</portName>
             <portName>fcrepo.dynamic.jms.port</portName>
             <portName>fcrepo.dynamic.stomp.port</portName>
+            <portName>fcrepo.dynamic.reindexing.port</portName>
+            <portName>karaf.rmiRegistry.port</portName>
+            <portName>karaf.rmiServer.port</portName>
+            <portName>karaf.ssh.port</portName>
             <portName>jetty.dynamic.stop.port</portName>
           </portNames>
         </configuration>
@@ -212,9 +216,13 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
+            <fcrepo.dynamic.reindexing.port>${fcrepo.dynamic.reindexing.port}</fcrepo.dynamic.reindexing.port>
             <fcrepo.dynamic.test.port>${fcrepo.dynamic.test.port}</fcrepo.dynamic.test.port>
             <fcrepo.dynamic.jms.port>${fcrepo.dynamic.jms.port}</fcrepo.dynamic.jms.port>
             <project.build.outputDirectory>${project.build.outputDirectory}</project.build.outputDirectory>
+            <karaf.ssh.port>${karaf.ssh.port}</karaf.ssh.port>
+            <karaf.rmiRegistry.port>${karaf.rmiRegistry.port}</karaf.rmiRegistry.port>
+            <karaf.rmiServer.port>${karaf.rmiServer.port}</karaf.rmiServer.port>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/toolbox-features/pom.xml
+++ b/toolbox-features/pom.xml
@@ -94,6 +94,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.ops4j.pax.exam</groupId>
       <artifactId>pax-exam-container-karaf</artifactId>
       <scope>test</scope>

--- a/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
+++ b/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
@@ -20,8 +20,9 @@ import static org.apache.http.impl.client.HttpClientBuilder.create;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.bundle;
+import static org.ops4j.pax.exam.CoreOptions.maven;
+import static org.ops4j.pax.exam.CoreOptions.systemProperty;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
@@ -65,6 +66,10 @@ public class KarafIT {
         final ConfigurationManager cm = new ConfigurationManager();
         final String fcrepoPort = cm.getProperty("fcrepo.dynamic.test.port");
         final String jmsPort = cm.getProperty("fcrepo.dynamic.jms.port");
+        final String reindexingPort = cm.getProperty("fcrepo.dynamic.reindexing.port");
+        final String rmiRegistryPort = cm.getProperty("karaf.rmiRegistry.port");
+        final String rmiServerPort = cm.getProperty("karaf.rmiServer.port");
+        final String sshPort = cm.getProperty("karaf.ssh.port");
         final String fcrepoFeatures = "file:" + cm.getProperty("project.build.outputDirectory") + "/features.xml";
         return new Option[] {
             karafDistributionConfiguration()
@@ -82,12 +87,17 @@ public class KarafIT {
             features(bundle(fcrepoFeatures).start(), "fcrepo-indexing-triplestore",
                     "fcrepo-indexing-solr", "fcrepo-reindexing", "fcrepo-serialization",
                     "fcrepo-fixity", "fcrepo-audit-triplestore"),
+            systemProperty("karaf.reindexing.port").value(reindexingPort),
+            editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiRegistryPort", rmiRegistryPort),
+            editConfigurationFilePut("etc/org.apache.karaf.management.cfg", "rmiServerPort", rmiServerPort),
+            editConfigurationFilePut("etc/org.apache.karaf.shell.cfg", "sshPort", sshPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.indexing.triplestore.cfg", "fcrepo.baseUrl", "localhost:" + fcrepoPort + "/fcrepo/rest"),
             editConfigurationFilePut("etc/org.fcrepo.camel.indexing.triplestore.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.indexing.solr.cfg", "fcrepo.baseUrl", "localhost:" + fcrepoPort + "/fcrepo/rest"),
             editConfigurationFilePut("etc/org.fcrepo.camel.indexing.solr.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.reindexing.cfg", "fcrepo.baseUrl", "localhost:" + fcrepoPort + "/fcrepo/rest"),
             editConfigurationFilePut("etc/org.fcrepo.camel.reindexing.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
+            editConfigurationFilePut("etc/org.fcrepo.camel.reindexing.cfg", "rest.port", reindexingPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.serialization.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.audit.triplestore.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.fixity.cfg", "jms.brokerUrl", "tcp://localhost:" + jmsPort),
@@ -109,7 +119,7 @@ public class KarafIT {
     @Test
     public void testReindexingService() throws Exception {
         final CloseableHttpClient client = create().build();
-        final String reindexingUrl = "http://localhost:9080/reindexing/";
+        final String reindexingUrl = "http://localhost:" + System.getProperty("karaf.reindexing.port") + "/reindexing/";
         try (final CloseableHttpResponse response = client.execute(new HttpGet(reindexingUrl))) {
             assertEquals(SC_OK, response.getStatusLine().getStatusCode());
         }

--- a/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
+++ b/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
@@ -33,11 +33,11 @@ import java.io.File;
 
 import javax.inject.Inject;
 
-import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.karaf.features.FeaturesService;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Update reindexing code to properly use the `camel-jetty` component in exposing an HTTP endpoint.

Resolves: https://jira.duraspace.org/browse/FCREPO-1980