### PR TITLE
Fixes the fcrepo-serialization tests

### DIFF
--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/AbstractRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/AbstractRouteTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractRouteTest extends CamelBlueprintTestSupport {
 
     @Override
     protected String getBlueprintDescriptor() {
-        return "/OSGI-INF/blueprint/blueprint.xml";
+        return "/OSGI-INF/blueprint/blueprint-test.xml";
     }
 
     @Override
@@ -64,8 +64,8 @@ public abstract class AbstractRouteTest extends CamelBlueprintTestSupport {
         props.put("serialization.stream", "seda:foo");
         props.put("input.stream", "seda:bar");
         props.put("serialization.format", "RDF_XML");
-        props.put("serialization.descriptions", "mock:direct:metadata_file");
-        props.put("serialization.binaries", "mock:direct:binary_file");
+        props.put("serialization.descriptions", "metadata_file");
+        props.put("serialization.binaries", "binary_file");
         // in here to clearly show that we won't include binaries by default
         props.put("serialization.includeBinaries", "false");
         props.put("audit.container", auditContainer);

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
@@ -35,7 +35,7 @@ import org.apache.commons.io.IOUtils;
  * @since 2015-09-28
  */
 
-public class RouteTestBinaryDisabled extends AbstractRouteTest {
+public class BinaryDisabledRouteTest extends AbstractRouteTest {
 
     @Test
     public void testMetatdataSerialization() throws Exception {
@@ -47,21 +47,22 @@ public class RouteTestBinaryDisabled extends AbstractRouteTest {
             }
         });
         context.start();
+
         getMockEndpoint("mock:direct:metadata").expectedMessageCount(1);
         getMockEndpoint("mock:direct:binary").expectedMessageCount(1);
         getMockEndpoint("mock:direct:delete").expectedMessageCount(0);
 
         // send a file!
         final String body = IOUtils.toString(ObjectHelper.loadResourceAsStream("binary.rdf"), "UTF-8");
-
         final Map<String, Object> headers = ImmutableMap.of(BASE_URL, baseURL);
 
         template.sendBodyAndHeaders(body, headers);
+
         assertMockEndpointsSatisfied();
     }
 
     @Test
-       public void testMetatdataSerializationRemoveNode() throws Exception {
+       public void testMetadataSerializationRemoveNode() throws Exception {
         context.getRouteDefinition("FcrepoSerialization").adviceWith(context, new AdviceWithRouteBuilder() {
             @Override
             public void configure() throws Exception {
@@ -80,7 +81,7 @@ public class RouteTestBinaryDisabled extends AbstractRouteTest {
         final Map<String, Object> headers = ImmutableMap.of(
             BASE_URL, baseURL,
             IDENTIFIER, identifier,
-            EVENT_TYPE, REPOSITORY + "NODE_REMOVE");
+            EVENT_TYPE, REPOSITORY + "NODE_REMOVED");
 
         template.sendBodyAndHeaders(body, headers);
 
@@ -146,7 +147,7 @@ public class RouteTestBinaryDisabled extends AbstractRouteTest {
         });
         context.start();
         // this should be zero because writing binaries is disabled by default.
-        getMockEndpoint("mock:direct:binary_file").expectedMessageCount(0);
+        getMockEndpoint("mock:file:binary_file").expectedMessageCount(0);
 
         // send a file!
         final String body = IOUtils.toString(ObjectHelper.loadResourceAsStream("binary.rdf"), "UTF-8");

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
@@ -16,15 +16,16 @@
 package org.fcrepo.camel.serialization;
 
 import static org.fcrepo.camel.JmsHeaders.BASE_URL;
-import static org.fcrepo.camel.JmsHeaders.IDENTIFIER;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
 
 import org.junit.Test;
 import java.util.Map;
 import java.util.Properties;
 
 import com.google.common.collect.ImmutableMap;
-import org.apache.camel.Exchange;
+
 import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.Exchange;
 import org.apache.camel.util.ObjectHelper;
 import org.apache.commons.io.IOUtils;
 
@@ -35,7 +36,7 @@ import org.apache.commons.io.IOUtils;
  * @since 2015-11-24
  */
 
-public class RouteTestBinaryEnabled extends AbstractRouteTest {
+public class BinaryEnabledRouteTest extends AbstractRouteTest {
 
     @Override
     protected Properties useOverridePropertiesWithPropertiesComponent() {
@@ -44,8 +45,8 @@ public class RouteTestBinaryEnabled extends AbstractRouteTest {
         props.put("serialization.stream", "seda:foo");
         props.put("input.stream", "seda:bar");
         props.put("serialization.format", "RDF_XML");
-        props.put("serialization.descriptions", "mock:direct:metadata_file");
-        props.put("serialization.binaries", "mock:direct:binary_file");
+        props.put("serialization.descriptions", "metadata_file");
+        props.put("serialization.binaries", "binary_file");
         props.put("serialization.includeBinaries", "true");
         props.put("audit.container", auditContainer);
 
@@ -64,14 +65,14 @@ public class RouteTestBinaryEnabled extends AbstractRouteTest {
         });
         context.start();
 
-        getMockEndpoint("mock:direct:binary_file").expectedMessageCount(1);
-        getMockEndpoint("mock:direct:binary_file").expectedHeaderReceived(Exchange.FILE_NAME, "foo");
+        getMockEndpoint("mock:file:binary_file").expectedMessageCount(1);
+        getMockEndpoint("mock:file:binary_file").expectedHeaderReceived(Exchange.FILE_NAME, "foo");
 
         // send a file!
         final String body = IOUtils.toString(ObjectHelper.loadResourceAsStream("binary.rdf"), "UTF-8");
         final Map<String, Object> headers = ImmutableMap.of(
             BASE_URL, baseURL,
-            IDENTIFIER, "foo");
+            FCREPO_IDENTIFIER, "foo");
 
         template.sendBodyAndHeaders(body, headers);
 


### PR DESCRIPTION
Cleans up the tests and actually makes them functional. 

fixes:  https://github.com/fcrepo4-exts/fcrepo-camel-toolbox/issues/96