### PR TITLE
Update dependencies

### DIFF
--- a/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditHeaders.java
+++ b/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditHeaders.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
+++ b/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/AuditSparqlProcessor.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
+++ b/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/ProcessorTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/integration/AuditSparqlIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-fixity/pom.xml
+++ b/fcrepo-fixity/pom.xml
@@ -180,6 +180,10 @@
               <name>fcrepo.dynamic.stomp.port</name>
               <value>${fcrepo.dynamic.stomp.port}</value>
             </systemProperty>
+            <systemProperty>
+              <name>fcrepo.modeshape.configuration</name>
+              <value>classpath:/config/minimal-default/repository.json</value>
+            </systemProperty>
           </systemProperties>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopKey>STOP</stopKey>

--- a/fcrepo-fixity/src/main/java/org/fcrepo/camel/fixity/FixityRouter.java
+++ b/fcrepo-fixity/src/main/java/org/fcrepo/camel/fixity/FixityRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/RouteTest.java
+++ b/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/integration/RouteIT.java
+++ b/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/integration/RouteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrDeleteProcessor.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrDeleteProcessor.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
+++ b/fcrepo-indexing-solr/src/main/java/org/fcrepo/camel/indexing/solr/SolrRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/DeleteProcessorTest.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/DeleteProcessorTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/RouteDeleteIT.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/RouteDeleteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/RouteUpdateIT.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/RouteUpdateIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -137,9 +139,8 @@ public class RouteUpdateIT extends CamelTestSupport {
         final Map<String, Object> headers = new HashMap<>();
         headers.put(JmsHeaders.IDENTIFIER, path);
         headers.put(JmsHeaders.BASE_URL, "http://localhost:" + webPort + "/rest");
-        headers.put(JmsHeaders.EVENT_TYPE, REPOSITORY + "NODE_ADDED");
+        headers.put(JmsHeaders.EVENT_TYPE, REPOSITORY + "ResourceCreation");
         headers.put(JmsHeaders.TIMESTAMP, 1428360320168L);
-        headers.put(JmsHeaders.PROPERTIES, "");
 
         getMockEndpoint(solrEndpoint).expectedMessageCount(1);
         getMockEndpoint(solrEndpoint).expectedHeaderReceived(Exchange.HTTP_RESPONSE_CODE, 200);

--- a/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/TestUtils.java
+++ b/fcrepo-indexing-solr/src/test/java/org/fcrepo/camel/indexing/solr/integration/TestUtils.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-solr/src/test/resources/spring-test/jms.xml
+++ b/fcrepo-indexing-solr/src/test/resources/spring-test/jms.xml
@@ -9,7 +9,7 @@
   <context:annotation-config/>
 
   <!-- publishes events from the internal bus to JMS -->
-  <bean class="org.fcrepo.jms.observer.JMSTopicPublisher"/>
+  <bean class="org.fcrepo.jms.JMSTopicPublisher"/>
 
   <bean id="connectionFactory"
     class="org.apache.activemq.ActiveMQConnectionFactory" depends-on="jmsBroker"
@@ -19,6 +19,6 @@
     p:config="${fcrepo.activemq.configuration:classpath:/config/activemq.xml}" p:start="true"/>
 
   <!-- translates events into JMS header-only format-->
-  <bean class="org.fcrepo.jms.headers.DefaultMessageFactory"/>
+  <bean class="org.fcrepo.jms.DefaultMessageFactory"/>
 
 </beans>

--- a/fcrepo-indexing-solr/src/test/resources/spring-test/rest.xml
+++ b/fcrepo-indexing-solr/src/test/resources/spring-test/rest.xml
@@ -14,6 +14,7 @@
 
   <!-- Identifier translation chain -->
   <util:list id="translationChain" value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+    <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter"/>
     <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter"/>
   </util:list>
 

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -192,6 +192,10 @@
                 <name>fcrepo.dynamic.stomp.port</name>
                 <value>${fcrepo.dynamic.stomp.port}</value>
               </systemProperty>
+              <systemProperty>
+                <name>fcrepo.modeshape.configuration</name>
+                <value>classpath:/config/minimal-default/repository.json</value>
+              </systemProperty>
             </systemProperties>
             <scanIntervalSeconds>10</scanIntervalSeconds>
             <stopKey>STOP</stopKey>

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/RouteTest.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteDeleteIT.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteDeleteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteUpdateIT.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteUpdateIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/TestUtils.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/TestUtils.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/ClientFactory.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/ClientFactory.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/FedoraEndpoint.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/FedoraEndpoint.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathRouter.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathWrapper.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathWrapper.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
+++ b/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/PathProcessor.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/PathProcessor.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingHeaders.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingHeaders.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/ReindexingRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/RestProcessor.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/RestProcessor.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/UsageProcessor.java
+++ b/fcrepo-reindexing/src/main/java/org/fcrepo/camel/reindexing/UsageProcessor.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/PathProcessorTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/PathProcessorTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RestProcessorTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RestProcessorTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/UsageProcessorTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/UsageProcessorTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/integration/RouteIT.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/integration/RouteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-serialization/pom.xml
+++ b/fcrepo-serialization/pom.xml
@@ -211,6 +211,10 @@
               <name>fcrepo.dynamic.stomp.port</name>
               <value>${fcrepo.dynamic.stomp.port}</value>
             </systemProperty>
+            <systemProperty>
+              <name>fcrepo.modeshape.configuration</name>
+              <value>classpath:/config/minimal-default/repository.json</value>
+            </systemProperty>
           </systemProperties>
           <scanIntervalSeconds>10</scanIntervalSeconds>
           <stopKey>STOP</stopKey>

--- a/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
+++ b/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/AbstractRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/AbstractRouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/integration/RouteIT.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/integration/RouteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-service-activemq/pom.xml
+++ b/fcrepo-service-activemq/pom.xml
@@ -239,6 +239,10 @@
                 <name>fcrepo.dynamic.stomp.port</name>
                 <value>${fcrepo.dynamic.stomp.port}</value>
               </systemProperty>
+              <systemProperty>
+                <name>fcrepo.modeshape.configuration</name>
+                <value>classpath:/config/minimal-default/repository.json</value>
+              </systemProperty>
             </systemProperties>
             <scanIntervalSeconds>10</scanIntervalSeconds>
             <stopKey>STOP</stopKey>

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -55,6 +57,8 @@ import org.ops4j.pax.exam.CoreOptions;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.karaf.options.LogLevelOption.LogLevel;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.util.tracker.ServiceTracker;
@@ -65,6 +69,7 @@ import org.slf4j.Logger;
  * @since May 4, 2016
  */
 @RunWith(PaxExam.class)
+@ExamReactorStrategy(PerClass.class)
 public class KarafIT {
 
     private static Logger LOGGER = getLogger(KarafIT.class);
@@ -134,13 +139,14 @@ public class KarafIT {
         assertNotNull(ctx);
 
         final MockEndpoint resultEndpoint = (MockEndpoint) ctx.getEndpoint("mock:result");
+        resultEndpoint.reset();
 
         final String url1 = post(baseUrl).replace(baseUrl, "");
         final String url2 = post(baseUrl).replace(baseUrl, "");
         final HttpPost post = new HttpPost(baseUrl);
 
-        resultEndpoint.expectedMinimumMessageCount(2);
-        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2);
+        resultEndpoint.expectedMessageCount(4);
+        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2, "", "");
         assertIsSatisfied(resultEndpoint);
     }
 

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -72,18 +74,17 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
     @Test
     public void testQueuingService() throws Exception {
+        resultEndpoint.reset();
         final String webPort = System.getProperty("fcrepo.dynamic.test.port", "8080");
 
         final String baseUrl = "http://localhost:" + webPort + "/fcrepo/rest";
         final String url1 = post(baseUrl).replace(baseUrl, "");
         final String url2 = post(baseUrl).replace(baseUrl, "");
 
-        resultEndpoint.expectedMinimumMessageCount(2);
-        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2);
+        resultEndpoint.expectedMessageCount(4);
+        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2, "", "");
 
         assertMockEndpointsSatisfied();
-        final String jmsPort = System.getProperty("fcrepo.dynamic.jms.port", "61616");
-        final String stompPort = System.getProperty("fcrepo.dynamic.stomp.port", "61613");
     }
 
     private String post(final String url) {

--- a/fcrepo-service-camel/pom.xml
+++ b/fcrepo-service-camel/pom.xml
@@ -232,6 +232,10 @@
                 <name>fcrepo.dynamic.stomp.port</name>
                 <value>${fcrepo.dynamic.stomp.port}</value>
               </systemProperty>
+              <systemProperty>
+                <name>fcrepo.modeshape.configuration</name>
+                <value>classpath:/config/minimal-default/repository.json</value>
+              </systemProperty>
             </systemProperties>
             <scanIntervalSeconds>10</scanIntervalSeconds>
             <stopKey>STOP</stopKey>

--- a/fcrepo-service-camel/src/test/java/org/fcrepo/camel/service/KarafIT.java
+++ b/fcrepo-service-camel/src/test/java/org/fcrepo/camel/service/KarafIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/fcrepo-service-camel/src/test/java/org/fcrepo/camel/service/RouteIT.java
+++ b/fcrepo-service-camel/src/test/java/org/fcrepo/camel/service/RouteIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.5.1</version>
+    <version>4.6.0</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
@@ -31,8 +31,8 @@
     <project.copyrightYear>2016</project.copyrightYear>
 
     <!-- dependencies -->
-    <activemq.version>5.13.2</activemq.version>
-    <camel.version>2.17.1</camel.version>
+    <activemq.version>5.14.0</activemq.version>
+    <camel.version>2.17.3</camel.version>
     <commons.lang3.version>3.4</commons.lang3.version>
     <jackson2.version>2.7.3</jackson2.version>
     <jena.version>2.13.0</jena.version>
@@ -41,23 +41,22 @@
     <mustache.version>0.9.1</mustache.version>
     <slf4j.version>1.7.20</slf4j.version>
     <spring.version>4.2.5.RELEASE</spring.version>
-    <fcrepo.version>4.5.1</fcrepo.version>
+    <fcrepo.version>4.6.0</fcrepo.version>
     <fcrepo-java-client.version>0.1.3</fcrepo-java-client.version>
     <fcrepo-camel.version>4.4.3</fcrepo-camel.version>
-    <fcrepo-build-tools.version>4.4.1</fcrepo-build-tools.version>
     <woodstox.version>4.4.1</woodstox.version>
     <!-- testing -->
     <awaitility.version>1.7.0</awaitility.version>
     <commons.codec.version>1.10</commons.codec.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.logging.version>1.1.3</commons.logging.version>
-    <grizzly.version>2.3.24</grizzly.version>
+    <grizzly.version>2.3.16</grizzly.version>
     <hamcrest.version>1.3</hamcrest.version>
     <httpclient.version>4.3.6</httpclient.version>
     <hk2.version>2.3.0</hk2.version>
     <jena.fuseki.version>1.1.1</jena.fuseki.version>
-    <jersey.version>2.15</jersey.version>
-    <karaf.version>4.0.4</karaf.version>
+    <jersey.version>2.22.2</jersey.version>
+    <karaf.version>4.0.6</karaf.version>
     <pax-exam.version>4.8.0</pax-exam.version>
     <solr.version>4.10.2</solr.version>
     <!-- osgi -->

--- a/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
+++ b/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2016 DuraSpace, Inc.
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-2147

Notably, this updates the testing apparatus to use Fedora 4.6.0