### PR TITLE
Remove dependency on JMS-based headers

### DIFF
--- a/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
+++ b/fcrepo-audit-triplestore/src/main/java/org/fcrepo/camel/audit/triplestore/EventRouter.java
@@ -60,7 +60,7 @@ public class EventRouter extends RouteBuilder {
             .setHeader(AuditHeaders.EVENT_BASE_URI, simple("{{event.baseUri}}"))
             .process(new AuditSparqlProcessor())
             .log(LoggingLevel.INFO, "org.fcrepo.camel.audit",
-                    "Audit Event: ${headers[org.fcrepo.jms.identifier]} :: ${headers[CamelAuditEventUri]}")
+                    "Audit Event: ${headers.CamelFcrepoUri} :: ${headers[CamelAuditEventUri]}")
             .to("{{triplestore.baseUrl}}?useSystemProperties=true");
     }
 }

--- a/fcrepo-ldpath/README.md
+++ b/fcrepo-ldpath/README.md
@@ -14,15 +14,16 @@ Note: The LDPath service requires an LDCache backend, such as `fcrepo-service-ld
 
 ## Usage
 
-The LDPath service responds to `GET` and `POST` requests at URL locations that map to Fedora resources.
+The LDPath service responds to `GET` and `POST` requests using any accessible resources as a context.
 
-For example, if the `fcrepo.baseUrl` is set as `http://localhost:8080/fcrepo/rest`, then a request to
-`http://localhost:9086/ldpath/path/to/fedora/object` will be applied to the Fedora resource at
-`http://localhost:8080/fcrepo/rest/path/to/fedora/object`.
+For example, a request to
+`http://localhost:9086/ldpath/?context=http://localhost/rest/path/to/fedora/object`
+will apply the appropriate ldpath program to the specified resource. Note: it is possible to
+identify non-Fedora resources in the context parameter.
 
 A `GET` request can include a `ldpath` parameter, pointing to the URL location of an LDPath program:
 
-    `curl http://localhost:9086/ldpath/path/to/fedora/object?ldpath=http://example.org/ldpath`
+    `curl http://localhost:9086/ldpath/?context=http://localhost/rest/path/to/fedora/object?ldpath=http://example.org/ldpath`
 
 Otherwise, it will use a simple default ldpath program.
 
@@ -30,8 +31,7 @@ A `POST` request can also be accepted by this endpoint. The body of a `POST` req
 the entire `LDPath` program. The `Content-Type` of the request should be either `text/plain` or
 `application/ldpath`.
 
-    `curl -XPOST -H"Content-Type: application/ldpath" -d @program.txt http://localhost:9086/ldpath/path/to/fedora/object
-
+    `curl -XPOST -H"Content-Type: application/ldpath" -d @program.txt http://localhost:9086/ldpath/?context=http://localhost/rest/path/to/fedora/object
 
 
 ## Building

--- a/fcrepo-ldpath/README.md
+++ b/fcrepo-ldpath/README.md
@@ -23,7 +23,7 @@ identify non-Fedora resources in the context parameter.
 
 A `GET` request can include a `ldpath` parameter, pointing to the URL location of an LDPath program:
 
-    `curl http://localhost:9086/ldpath/?context=http://localhost/rest/path/to/fedora/object?ldpath=http://example.org/ldpath`
+    `curl http://localhost:9086/ldpath/?context=http://localhost/rest/path/to/fedora/object&ldpath=http://example.org/ldpath`
 
 Otherwise, it will use a simple default ldpath program.
 

--- a/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathRouter.java
+++ b/fcrepo-ldpath/src/main/java/org/fcrepo/camel/ldpath/LDPathRouter.java
@@ -57,7 +57,7 @@ public class LDPathRouter extends RouteBuilder {
                 .when(not(and(header("context").isNotNull(), header("context").regex("^https?://.+"))))
                     .setHeader(HTTP_RESPONSE_CODE).constant(400)
                     .setHeader(CONTENT_TYPE).constant("text/plain")
-                    .transform(constant("Missing context paramter"))
+                    .transform(constant("Missing context parameter"))
                 .when(header(HTTP_METHOD).isEqualTo("GET"))
                     .to("direct:get")
                 .when(header(HTTP_METHOD).isEqualTo("POST"))

--- a/fcrepo-ldpath/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-ldpath/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -78,7 +78,7 @@
     <route id="FcrepoLDPath">
       <from uri="direct:ldpath"/>
       <setBody>
-        <method ref="ldpath" method="programQuery(${headers.CamelFedoraUri}, ${body})"/>
+        <method ref="ldpath" method="programQuery(${headers.context}, ${body})"/>
       </setBody>
     </route>
 

--- a/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
+++ b/fcrepo-ldpath/src/test/java/org/fcrepo/camel/ldpath/RouteTest.java
@@ -21,7 +21,6 @@ import static org.apache.camel.Exchange.CONTENT_TYPE;
 import static org.apache.camel.Exchange.HTTP_URI;
 import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
-import static org.fcrepo.camel.ldpath.LDPathRouter.FEDORA_URI;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -116,7 +115,7 @@ public class RouteTest extends CamelBlueprintTestSupport {
         });
         context.start();
 
-        template.sendBodyAndHeader("direct:get", null, FEDORA_URI, uri);
+        template.sendBodyAndHeader("direct:get", null, "context", uri);
 
         assertMockEndpointsSatisfied();
         final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);
@@ -152,7 +151,7 @@ public class RouteTest extends CamelBlueprintTestSupport {
 
         final Map<String, Object> headers = new HashMap<>();
         headers.put("ldpath", "http://example.org/ldpath");
-        headers.put(FEDORA_URI, uri);
+        headers.put("context", uri);
         template.sendBodyAndHeaders("direct:get", loadResourceAsStream("test.ldpath"), headers);
 
         assertMockEndpointsSatisfied();
@@ -183,7 +182,7 @@ public class RouteTest extends CamelBlueprintTestSupport {
         });
         context.start();
 
-        template.sendBodyAndHeader("direct:ldpathPrepare", loadResourceAsStream("test.ldpath"), FEDORA_URI, uri);
+        template.sendBodyAndHeader("direct:ldpathPrepare", loadResourceAsStream("test.ldpath"), "context", uri);
 
         assertMockEndpointsSatisfied();
         final String result = resultEndpoint.getExchanges().get(0).getIn().getBody(String.class);

--- a/fcrepo-ldpath/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/fcrepo-ldpath/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -72,7 +72,7 @@
     <route id="FcrepoLDPath">
       <from uri="direct:ldpath"/>
       <setBody>
-        <method ref="ldpath" method="programQuery(${headers.CamelFedoraUri}, ${body})"/>
+        <method ref="ldpath" method="programQuery(${headers.context}, ${body})"/>
       </setBody>
     </route>
 

--- a/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
+++ b/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
@@ -17,13 +17,13 @@
  */
 package org.fcrepo.camel.serialization;
 
+import static java.net.URI.create;
 import static org.apache.camel.LoggingLevel.INFO;
 import static org.apache.camel.LoggingLevel.DEBUG;
 import static org.apache.camel.Exchange.FILE_NAME;
 import static org.apache.camel.builder.PredicateBuilder.not;
 import static org.apache.camel.builder.PredicateBuilder.or;
 import static org.apache.camel.component.exec.ExecBinding.EXEC_COMMAND_ARGS;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_BASE_URL;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_EVENT_TYPE;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
@@ -75,8 +75,11 @@ public class SerializationRouter extends RouteBuilder {
         from("{{input.stream}}")
             .routeId("FcrepoSerialization")
             .process(new EventProcessor())
-            // this is a hard dependency on the jms module and should be reworked
-            .setHeader(FCREPO_IDENTIFIER).header("org.fcrepo.jms.identifier")
+            .process(exchange -> {
+                final String uri = exchange.getIn().getHeader(FCREPO_URI, "", String.class);
+                exchange.getIn().setHeader(FCREPO_IDENTIFIER, create(uri).getPath());
+            })
+
             .filter(not(or(header(FCREPO_URI).startsWith(simple("{{audit.container}}/")),
                     header(FCREPO_URI).isEqualTo(simple("{{audit.container}}")))))
             .choice()
@@ -91,30 +94,27 @@ public class SerializationRouter extends RouteBuilder {
             .filter(not(or(header(FCREPO_URI).startsWith(simple("{{audit.container}}/")),
                     header(FCREPO_URI).isEqualTo(simple("{{audit.container}}")))))
             .process(exchange -> {
-                final String baseUrl = exchange.getIn().getHeader(FCREPO_BASE_URL, "", String.class);
                 final String uri = exchange.getIn().getHeader(FCREPO_URI, "", String.class);
-                exchange.getIn().setHeader(FCREPO_IDENTIFIER, uri.replaceAll(baseUrl, ""));
+                exchange.getIn().setHeader(FCREPO_IDENTIFIER, create(uri).getPath());
             })
             .multicast().to("direct:metadata", "direct:binary");
 
         from("direct:metadata")
             .routeId("FcrepoSerializationMetadataUpdater")
-            .to("fcrepo:{{fcrepo.baseUrl}}?accept={{serialization.mimeType}}")
-            .log(INFO, LOGGER,
-                    "Serializing object ${headers[CamelFcrepoIdentifier]}")
-            .setHeader(FILE_NAME)
-                .simple("${headers[CamelFcrepoIdentifier]}.{{serialization.extension}}")
+            .to("fcrepo:localhost?accept={{serialization.mimeType}}")
+            .log(INFO, LOGGER, "Serializing object ${headers[CamelFcrepoIdentifier]}")
+            .setHeader(FILE_NAME).simple("${headers[CamelFcrepoIdentifier]}.{{serialization.extension}}")
             .log(DEBUG, LOGGER, "filename is ${headers[CamelFileName]}")
             .to("file://{{serialization.descriptions}}");
 
         from("direct:binary")
             .routeId("FcrepoSerializationBinaryUpdater")
             .filter().simple("{{serialization.includeBinaries}} == 'true'")
-            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer" +
+            .to("fcrepo:localhost?preferInclude=PreferMinimalContainer" +
                     "&accept=application/rdf+xml")
             .filter().xpath(isBinaryResourceXPath, ns)
             .log(INFO, LOGGER, "Writing binary ${headers[CamelFcrepoIdentifier]}")
-            .to("fcrepo:{{fcrepo.baseUrl}}?metadata=false")
+            .to("fcrepo:localhost?metadata=false")
             .setHeader(FILE_NAME).header(FCREPO_IDENTIFIER)
             .log(DEBUG, LOGGER, "header filename is: ${headers[CamelFileName]}")
             .to("file://{{serialization.binaries}}");

--- a/fcrepo-serialization/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/fcrepo-serialization/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -11,7 +11,6 @@
   <cm:property-placeholder id="properties" persistent-id="org.fcrepo.camel.serialization" update-strategy="reload">
     <cm:default-properties>
         <cm:property name="error.maxRedeliveries" value="10"/>
-        <cm:property name="fcrepo.baseUrl" value="http://localhost:8080/fcrepo/rest"/>
         <cm:property name="input.stream" value="broker:topic:fedora"/>
         <cm:property name="serialization.stream" value="broker:queue:serialization"/>
         <cm:property name="serialization.descriptions" value="/tmp/descriptions"/>

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
@@ -50,7 +50,7 @@ public class BinaryDisabledRouteTest extends AbstractRouteTest {
         getMockEndpoint("mock:direct:delete").expectedMessageCount(0);
 
         // send a file!
-        template.sendBodyAndHeader(loadResourceAsStream("event.json"), "org.fcrepo.jms.identifier", identifier);
+        template.sendBody(loadResourceAsStream("event.json"));
 
         assertMockEndpointsSatisfied();
     }
@@ -70,8 +70,7 @@ public class BinaryDisabledRouteTest extends AbstractRouteTest {
         getMockEndpoint("mock:direct:binary").expectedMessageCount(0);
         getMockEndpoint("mock:direct:delete").expectedMessageCount(1);
 
-        template.sendBodyAndHeader(loadResourceAsStream("event_delete_resource.json"),
-                "org.fcrepo.jms.identifier", identifier);
+        template.sendBody(loadResourceAsStream("event_delete_resource.json"));
 
         assertMockEndpointsSatisfied();
     }

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryDisabledRouteTest.java
@@ -18,8 +18,8 @@
 package org.fcrepo.camel.serialization;
 
 import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.fcrepo.camel.serialization.SerializationRouter.SERIALIZATION_PATH;
 
 import org.junit.Test;
 
@@ -129,7 +129,7 @@ public class BinaryDisabledRouteTest extends AbstractRouteTest {
         // this should be zero because writing binaries is disabled by default.
         getMockEndpoint("mock:file:binary_file").expectedMessageCount(0);
 
-        template.sendBodyAndHeader(loadResourceAsStream("binary.rdf"), FCREPO_IDENTIFIER, "/foo");
+        template.sendBodyAndHeader(loadResourceAsStream("binary.rdf"), SERIALIZATION_PATH, "/foo");
 
         assertMockEndpointsSatisfied();
     }

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/BinaryEnabledRouteTest.java
@@ -19,7 +19,7 @@ package org.fcrepo.camel.serialization;
 
 import static org.apache.camel.Exchange.FILE_NAME;
 import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_IDENTIFIER;
+import static org.fcrepo.camel.serialization.SerializationRouter.SERIALIZATION_PATH;
 
 import org.junit.Test;
 import java.util.Properties;
@@ -69,7 +69,7 @@ public class BinaryEnabledRouteTest extends AbstractRouteTest {
         // send a file!
         final String body = IOUtils.toString(loadResourceAsStream("binary.rdf"), "UTF-8");
 
-        template.sendBodyAndHeader(body, FCREPO_IDENTIFIER, "/foo");
+        template.sendBodyAndHeader(body, SERIALIZATION_PATH, "/foo");
 
         assertMockEndpointsSatisfied();
     }

--- a/fcrepo-serialization/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/fcrepo-serialization/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -11,7 +11,6 @@
   <cm:property-placeholder id="properties" persistent-id="org.fcrepo.camel.serialization" update-strategy="reload">
     <cm:default-properties>
         <cm:property name="error.maxRedeliveries" value="10"/>
-        <cm:property name="fcrepo.baseUrl" value="localhost:8080/fcrepo/rest"/>
         <cm:property name="input.stream" value="broker:topic:fedora"/>
         <cm:property name="serialization.stream" value="broker:queue:serialization"/>
         <cm:property name="serialization.descriptions" value="/tmp/descriptions"/>

--- a/fcrepo-service-activemq/pom.xml
+++ b/fcrepo-service-activemq/pom.xml
@@ -76,6 +76,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-jackson</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.fcrepo.camel</groupId>
+      <artifactId>fcrepo-camel</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
@@ -20,6 +20,7 @@ package org.fcrepo.camel.service.activemq;
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.apache.http.impl.client.HttpClientBuilder.create;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -109,6 +110,8 @@ public class KarafIT {
                         "camel-blueprint", "camel-http4", "camel-jms"),
             features(maven().groupId("org.apache.activemq").artifactId("activemq-karaf")
                         .type("xml").classifier("features").versionAsInProject(), "activemq-camel"),
+            features(maven().groupId("org.fcrepo.camel").artifactId("fcrepo-camel")
+                        .type("xml").classifier("features").versionAsInProject(), "fcrepo-camel"),
 
             CoreOptions.systemProperty("fcrepo.port").value(fcrepoPort),
             CoreOptions.systemProperty("jms.port").value(jmsPort),
@@ -154,12 +157,11 @@ public class KarafIT {
         final MockEndpoint resultEndpoint = (MockEndpoint) ctx.getEndpoint("mock:result");
         resultEndpoint.reset();
 
-        final String url1 = post(baseUrl).replace(baseUrl, "");
-        final String url2 = post(baseUrl).replace(baseUrl, "");
-        final HttpPost post = new HttpPost(baseUrl);
+        final String url1 = post(baseUrl);
+        final String url2 = post(baseUrl);
 
         resultEndpoint.expectedMessageCount(4);
-        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2, "", "");
+        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder(FCREPO_URI, url1, url2, baseUrl, baseUrl);
         assertIsSatisfied(resultEndpoint);
     }
 

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
@@ -18,6 +18,7 @@
 package org.fcrepo.camel.service.activemq;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
@@ -78,11 +79,11 @@ public class RouteIT extends CamelBlueprintTestSupport {
         final String webPort = System.getProperty("fcrepo.dynamic.test.port", "8080");
 
         final String baseUrl = "http://localhost:" + webPort + "/fcrepo/rest";
-        final String url1 = post(baseUrl).replace(baseUrl, "");
-        final String url2 = post(baseUrl).replace(baseUrl, "");
+        final String url1 = post(baseUrl);
+        final String url2 = post(baseUrl);
 
         resultEndpoint.expectedMessageCount(4);
-        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder("org.fcrepo.jms.identifier", url1, url2, "", "");
+        resultEndpoint.expectedHeaderValuesReceivedInAnyOrder(FCREPO_URI, url1, url2, baseUrl, baseUrl);
 
         assertMockEndpointsSatisfied();
     }

--- a/fcrepo-service-activemq/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
+++ b/fcrepo-service-activemq/src/test/resources/OSGI-INF/blueprint/blueprint-test.xml
@@ -7,9 +7,12 @@
 
   <reference id="broker" interface="org.apache.camel.Component" filter="(osgi.jndi.service.name=fcrepo/Broker)"/>
 
+  <bean id="fcrepoEvent" class="org.fcrepo.camel.processor.EventProcessor"/>
+
   <camelContext id="FcrepoQueuingService" xmlns="http://camel.apache.org/schema/blueprint">
     <route id="testRoute">
       <from uri="broker:topic:fedora"/>
+      <process ref="fcrepoEvent"/>
       <to uri="mock:result"/>
     </route>
   </camelContext>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.camel</groupId>
+        <artifactId>camel-jackson</artifactId>
+        <version>${camel.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.camel</groupId>
         <artifactId>camel-spring</artifactId>
         <version>${camel.version}</version>
       </dependency>


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-2333

The major change here is that the `fcrepo-ldpath` component's interface changes. The existing behavior is such that requests map a path like this `http://localhost:7777/ldpath/some/fedora/resource` to a particular fedora resource (e.g. `http://localhost:8080/fcrepo/rest/some/fedora/resource`). 

This PR changes that to be more generic: `http://localhost:7777/ldpath?context=http://localhost:8080/fcrepo/rest/some/fedora/resource`

This change also makes the ldpath component more general such that requests can start from _any_ linked data resource, not just Fedora resources. This change simplifies the code in both `fcrepo-ldpath` and `fcrepo-indexing-solr`, making it unnecessary to rely on the JMS headers as outlined above.

The other change relates to the serialization tool. The existing implementation uses the `org.fcrepo.jms.identifier` value to set the location of a filename. With this PR, the module uses the resource path, so `http://localhost:8080/fcrepo/rest/path/to/resource` would map to a file at `${configuredBaseDir}/fcrepo/rest/path/to/resource` (by way of comparison, the current behavior would store that resource at `${configuredBaseDir}/path/to/resource`.