### PR TITLE
Start using released version of fcrepo-camel/4.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <spring.version>4.2.5.RELEASE</spring.version>
     <fcrepo.version>4.7.0</fcrepo.version>
     <fcrepo-java-client.version>0.2.1</fcrepo-java-client.version>
-    <fcrepo-camel.version>4.5.0-SNAPSHOT</fcrepo-camel.version>
+    <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
     <woodstox.version>4.4.1</woodstox.version>
     <!-- testing -->
     <awaitility.version>1.7.0</awaitility.version>


### PR DESCRIPTION
Now that fcrepo-camel/4.5.0 is available on maven central, we should use it instead of using the SNAPSHOT artifacts.