### PR TITLE
Updates fcrepo-camel-toolbox to work with Fedora 5.x.

### DIFF
--- a/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
+++ b/fcrepo-audit-triplestore/src/test/java/org/fcrepo/camel/audit/triplestore/RouteTest.java
@@ -51,9 +51,6 @@ public class RouteTest extends CamelBlueprintTestSupport {
     private static final String baseURL = "http://localhost/rest";
     private static final String fileID = "/file1";
     private static final String auditContainer = "/audit";
-    private static final String eventDate = "2015-04-06T22:45:20Z";
-    private static final String userID = "fedo raAdmin";
-    private static final String userAgent = "CLAW client/1.0";
 
     @Override
     protected String getBlueprintDescriptor() {

--- a/fcrepo-audit-triplestore/src/test/resources/event_audit_resource.json
+++ b/fcrepo-audit-triplestore/src/test/resources/event_audit_resource.json
@@ -1,36 +1,38 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/audit/1234" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a11",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Create" ],
+  "name": "create resource",
+  "published": "2016-05-19T17:17:40-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/audit/1234" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "http://fedora.info/definitions/v4/event#ResourceCreation" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }
+

--- a/fcrepo-audit-triplestore/src/test/resources/event_audit_update.json
+++ b/fcrepo-audit-triplestore/src/test/resources/event_audit_update.json
@@ -1,36 +1,37 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/audit" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a12",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Update" ],
+  "name": "update resource",
+  "published": "2016-05-19T17:17:41-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/audit" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "http://fedora.info/definitions/v4/event#ResourceModification" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-audit-triplestore/src/test/resources/event_delete_binary.json
+++ b/fcrepo-audit-triplestore/src/test/resources/event_delete_binary.json
@@ -1,36 +1,36 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/file1" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a13",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Binary" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Delete" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:42-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/file1" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "https://www.w3.org/ns/activitystreams#Delete" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Binary" ,
+      "http://www.w3.org/ns/ldp#NonRDFSource" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-audit-triplestore/src/test/resources/event_delete_resource.json
+++ b/fcrepo-audit-triplestore/src/test/resources/event_delete_resource.json
@@ -1,37 +1,37 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/auditions/1234" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a14",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ,
-    "http://example.org/CustomType" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Delete" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:43-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/auditions/1234" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "https://www.w3.org/ns/activitystreams#Delete" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-fixity/pom.xml
+++ b/fcrepo-fixity/pom.xml
@@ -181,13 +181,14 @@
               <goal>start</goal>
             </goals>
             <configuration>
+              <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
               <httpConnector>
                 <port>${fcrepo.dynamic.test.port}</port>
               </httpConnector>
               <scanIntervalSeconds>0</scanIntervalSeconds>
               <daemon>true</daemon>
               <contextHandlers>
-                  <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                  <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                     <war>${project.build.directory}/fcrepo.war</war>
                     <contextPath>/fcrepo</contextPath>
                   </contextHandler>

--- a/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/integration/RouteIT.java
+++ b/fcrepo-fixity/src/test/java/org/fcrepo/camel/fixity/integration/RouteIT.java
@@ -53,6 +53,9 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
     private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";
 
+    private static String FEDORA_USERNAME = "fedoraAdmin";
+    private static String FEDORA_PASSWORD = "fedoraAdmin";
+
     @EndpointInject(uri = "mock:result")
     protected MockEndpoint resultEndpoint;
 
@@ -66,7 +69,8 @@ public class RouteIT extends CamelBlueprintTestSupport {
     @Override
     protected void doPreSetup() throws Exception {
         final String webPort = System.getProperty("fcrepo.dynamic.test.port", "8080");
-        final FcrepoClient client = client().throwExceptionOnFailure().build();
+        final FcrepoClient client = client().throwExceptionOnFailure()
+                                            .credentials(FEDORA_USERNAME, FEDORA_PASSWORD).build();
         final FcrepoResponse res = client.post(URI.create("http://localhost:" + webPort + "/fcrepo/rest"))
                                 .body(loadResourceAsStream(binary), "text/plain").perform();
         fullPath = res.getLocation().toString();
@@ -109,7 +113,8 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
         final FcrepoComponent fcrepo = new FcrepoComponent();
         fcrepo.setBaseUrl("http://localhost:" + webPort + "/fcrepo/rest");
-
+        fcrepo.setAuthUsername(FEDORA_USERNAME);
+        fcrepo.setAuthPassword(FEDORA_PASSWORD);
         services.put("broker", asService(component, "osgi.jndi.service.name", "fcrepo/Broker"));
         services.put("fcrepo", asService(fcrepo, "osgi.jndi.service.name", "fcrepo/Camel"));
     }
@@ -134,7 +139,6 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
         getMockEndpoint(fcrepoEndpoint).expectedMessageCount(2);
         getMockEndpoint("mock:success").expectedMessageCount(1);
-
         template.sendBodyAndHeader("direct:start", "", FCREPO_URI,
                 "http://localhost:" + webPort + "/fcrepo/rest" + path);
 

--- a/fcrepo-fixity/src/test/resources/jetty-test.xml
+++ b/fcrepo-fixity/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-fixity/src/test/resources/jetty-users.properties
+++ b/fcrepo-fixity/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/fcrepo-indexing-solr/src/test/resources/event_delete_resource.json
+++ b/fcrepo-indexing-solr/src/test/resources/event_delete_resource.json
@@ -1,37 +1,39 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/auditions/1234" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ,
-    "http://example.org/CustomType" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Delete" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:39-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+
+  "object" : {
+    "id" : "http://localhost/rest/auditions/1234" ,
+    "isPartOf" : "http://localhost/rest" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "https://www.w3.org/ns/activitystreams#Delete" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer",
+      "http://example.org/CustomType" ]
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-indexing-triplestore/pom.xml
+++ b/fcrepo-indexing-triplestore/pom.xml
@@ -188,13 +188,14 @@
                 <goal>start</goal>
               </goals>
               <configuration>
+                <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
                 <httpConnector>
                   <port>${fcrepo.dynamic.test.port}</port>
                 </httpConnector>
                 <scanIntervalSeconds>0</scanIntervalSeconds>
                 <daemon>true</daemon>
                 <contextHandlers>
-                    <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                    <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                       <war>${project.build.directory}/fcrepo.war</war>
                       <contextPath>/fcrepo</contextPath>
                     </contextHandler>

--- a/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
+++ b/fcrepo-indexing-triplestore/src/main/java/org/fcrepo/camel/indexing/triplestore/TriplestoreRouter.java
@@ -53,6 +53,9 @@ public class TriplestoreRouter extends RouteBuilder {
      */
     public void configure() throws Exception {
 
+        final String AUTH_PARAMS = "authUsername=" + System.getProperty("fcrepo.authUsername", "fedoraAdmin") +
+                "&authPassword=" + System.getProperty("fcrepo.authPassword", "fedoraAdmin");
+
         final Namespaces ns = new Namespaces("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#");
         ns.add("indexing", "http://fedora.info/definitions/v4/indexing#");
 
@@ -104,7 +107,8 @@ public class TriplestoreRouter extends RouteBuilder {
                 .when(simple("{{indexing.predicate}} != 'true'"))
                     .to("direct:update.triplestore")
                 .otherwise()
-                    .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=PreferMinimalContainer&accept=application/rdf+xml")
+                    .to("fcrepo:{{fcrepo.baseUrl}}?" + AUTH_PARAMS +
+                            "&preferInclude=PreferMinimalContainer&accept=application/rdf+xml")
                     .choice()
                         .when(indexable)
                             .to("direct:update.triplestore")
@@ -128,7 +132,7 @@ public class TriplestoreRouter extends RouteBuilder {
             .routeId("FcrepoTriplestoreUpdater")
             .setHeader(FCREPO_NAMED_GRAPH)
                 .simple("{{triplestore.namedGraph}}")
-            .to("fcrepo:{{fcrepo.baseUrl}}?accept=application/n-triples" +
+            .to("fcrepo:{{fcrepo.baseUrl}}?" + AUTH_PARAMS + "&accept=application/n-triples" +
                     "&preferOmit={{prefer.omit}}&preferInclude={{prefer.include}}")
             .process(new SparqlUpdateProcessor())
             .log(LoggingLevel.INFO, LOGGER,

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteDeleteIT.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteDeleteIT.java
@@ -21,8 +21,8 @@ import static java.lang.Integer.parseInt;
 import static com.jayway.awaitility.Awaitility.await;
 import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.camel.indexing.triplestore.integration.TestUtils.createClient;
 import static org.fcrepo.camel.indexing.triplestore.integration.TestUtils.getEvent;
-import static org.fcrepo.client.FcrepoClient.client;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -81,7 +81,7 @@ public class RouteDeleteIT extends CamelBlueprintTestSupport {
 
     @Before
     public void setUpFuseki() throws Exception {
-        final FcrepoClient client = client().throwExceptionOnFailure().build();
+        final FcrepoClient client = createClient();
         final FcrepoResponse res = client.post(URI.create("http://localhost:" + FCREPO_PORT + "/fcrepo/rest"))
                     .body(loadResourceAsStream("container.ttl"), "text/turtle").perform();
         fullPath = res.getLocation().toString();

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteUpdateIT.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/RouteUpdateIT.java
@@ -21,8 +21,8 @@ import static java.lang.Integer.parseInt;
 import static com.jayway.awaitility.Awaitility.await;
 import static org.apache.camel.util.ObjectHelper.loadResourceAsStream;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.fcrepo.camel.indexing.triplestore.integration.TestUtils.createClient;
 import static org.fcrepo.camel.indexing.triplestore.integration.TestUtils.getEvent;
-import static org.fcrepo.client.FcrepoClient.client;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -78,7 +78,8 @@ public class RouteUpdateIT extends CamelBlueprintTestSupport {
 
     @Override
     protected void doPreSetup() throws Exception {
-        final FcrepoClient client = client().throwExceptionOnFailure().build();
+        final FcrepoClient client = createClient();
+
         final FcrepoResponse res = client.post(URI.create("http://localhost:" + FCREPO_PORT + "/fcrepo/rest"))
                   .body(loadResourceAsStream("indexable.ttl"), "text/turtle").perform();
         fullPath = res.getLocation().toString();

--- a/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/TestUtils.java
+++ b/fcrepo-indexing-triplestore/src/test/java/org/fcrepo/camel/indexing/triplestore/integration/TestUtils.java
@@ -29,6 +29,9 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.fcrepo.client.FcrepoClient;
+
+import static org.fcrepo.client.FcrepoClient.client;
 
 /**
  * Utility functions for the integration tests
@@ -37,6 +40,9 @@ import org.apache.http.impl.client.HttpClients;
  * @since 2015-04-21
  */
 public class TestUtils {
+
+    private static String FEDORA_USERNAME = "fedoraAdmin";
+    private static String FEDORA_PASSWORD = "fedoraAdmin";
 
     /**
      *  Format a Sparql-update for the provided subject.
@@ -76,37 +82,41 @@ public class TestUtils {
      * @return the event message as JSON
      */
     public static String getEvent(final String subject, final String eventType) {
-        return "{\"@context\" : {" +
-            "\"prov\" : \"http://www.w3.org/ns/prov#\" ," +
-            "\"foaf\" : \"http://xmlns.com/foaf/0.1/\" ," +
-            "\"dcterms\" : \"http://purl.org/dc/terms/\" ," +
-            "\"xsd\" : \"http://www.w3.org/2001/XMLSchema#\" ," +
-            "\"type\" : \"@type\" , " +
-            "\"id\" : \"@id\" ," +
-            "\"atTime\" : { \"@id\" : \"prov:atTime\", \"@type\" : \"xsd:dateTime\" } ," +
-            "\"identifier\" : { \"@id\" : \"dcterms:identifier\" , \"@type\" : \"@id\" } ," +
-            "\"isPartOf\" : { \"@id\" : \"dcterms:isPartOf\", \"@type\" : \"@id\" } ," +
-            "\"name\" : { \"@id\" : \"foaf:name\", \"@type\" : \"xsd:string\" } ," +
-            "\"wasAttributedTo\" : { \"@id\" : \"prov:wasAttributedTo\", \"@type\" : \"@id\" } ," +
-            "\"wasGeneratedBy\" : { \"@id\" : \"prov:wasGeneratedBy\", \"@type\" : \"@id\" }" +
-          "} ," +
-          "\"id\" : \"" + subject + "\" ," +
-          "\"type\" : [ " +
-            "\"http://www.w3.org/ns/prov#Entity\" ," +
-            "\"http://fedora.info/definitions/v4/repository#Resource\" ," +
-            "\"http://fedora.info/definitions/v4/repository#Container\" ] ," +
-          "\"wasGeneratedBy\" : {" +
-            "\"type\" : [" +
-              "\"http://www.w3.org/ns/prov#Activity\" ," +
-              "\"" + eventType + "\" ] ," +
-            "\"identifier\" : \"urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18\" ," +
-            "\"atTime\" : \"2016-05-19T17:17:39-04:00Z\" } ," +
-          "\"wasAttributedTo\" : [" +
-            "{ \"type\" : \"http://www.w3.org/ns/prov#Person\" ," +
-              "\"name\" : \"fedo raAdmin\" }," +
-            "{ \"type\" : \"http://www.w3.org/ns/prov#SoftwareAgent\" ," +
-              "\"name\" : \"CLAW client/1.0\" } ]" +
-        "}";
+        return "{\n" +
+                "\"id\": \"urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18\", \n" +
+                "\"type\" : [ \"http://www.w3.org/ns/prov#Activity\" ,\n" +
+                "             \"" + eventType + "\" ],\n" +
+                "\"name\": \"resource event\",\n" +
+                "        \"published\": \"2016-05-19T17:17:43-04:00Z\",\n" +
+                "        \"actor\": [{\n" +
+                "   \"type\": [\"Person\"],\n" +
+                "    \"id\": \"info:fedora/fedoraAdmin\"\n" +
+                "}, {\n" +
+                "    \"type\": [\"Application\"],\n" +
+                "    \"name\": \"CLAW client/1.0\"\n" +
+                "}],\n" +
+                "        \n" +
+                "\"object\" : {\n" +
+                "    \"id\" : \"" + subject + "\" ,\n" +
+                "            \"type\" : [\n" +
+                "    \"http://www.w3.org/ns/prov#Entity\" ,\n" +
+                "            \"http://fedora.info/definitions/v4/repository#Resource\" ,\n" +
+                "            \"http://fedora.info/definitions/v4/repository#Container\" ,\n" +
+                "            \"http://www.w3.org/ns/ldp#RDFSource\",\n" +
+                "           \"http://www.w3.org/ns/ldp#BasicContainer\" ],\n" +
+                "    \"isPartOf\" : \"http://localhost/rest\"\n" +
+                "},\n" +
+                " \n" +
+                "\"@context\": [\"https://www.w3.org/ns/activitystreams\", {\n" +
+                "       \"prov\": \"http://www.w3.org/ns/prov#\",\n" +
+                "        \"dcterms\": \"http://purl.org/dc/terms/\",\n" +
+                "       \"type\": \"@type\",\n" +
+                "        \"id\": \"@id\",\n" +
+                "        \"isPartOf\": {\n" +
+                "    \"@id\": \"dcterms:isPartOf\",\n" +
+                "            \"@type\": \"@id\"\n" +
+                "}}]\n" +
+                "}";
     }
 
     /**
@@ -156,6 +166,15 @@ public class TestUtils {
                         .get("results").get("bindings").get(0).get("n").get("value").asText(), 10);
             }
         };
+    }
+
+    /**
+     * Create a new FcrepoClient instance with authentication.
+     * @return the newly created client
+     */
+    public static FcrepoClient createClient() {
+        return client().throwExceptionOnFailure()
+                .credentials(FEDORA_USERNAME, FEDORA_PASSWORD).build();
     }
 
     private TestUtils() {

--- a/fcrepo-indexing-triplestore/src/test/resources/event_delete_resource.json
+++ b/fcrepo-indexing-triplestore/src/test/resources/event_delete_resource.json
@@ -1,37 +1,37 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/some/resource" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ,
-    "http://example.org/CustomType" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Delete" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:43-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/some/resource" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "https://www.w3.org/ns/activitystreams#Delete" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-indexing-triplestore/src/test/resources/jetty-test.xml
+++ b/fcrepo-indexing-triplestore/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-indexing-triplestore/src/test/resources/jetty-users.properties
+++ b/fcrepo-indexing-triplestore/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/fcrepo-reindexing/pom.xml
+++ b/fcrepo-reindexing/pom.xml
@@ -163,6 +163,7 @@
 
 
         <!-- Launch jetty for integration testing with fedora -->
+
         <plugin>
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-maven-plugin</artifactId>
@@ -176,10 +177,6 @@
               <systemProperty>
                 <name>fcrepo.dynamic.reindexing.port</name>
                 <value>${fcrepo.dynamic.reindexing.port}</value>
-              </systemProperty>
-              <systemProperty>
-                <name>fcrepo.dynamic.test.port</name>
-                <value>${fcrepo.dynamic.test.port}</value>
               </systemProperty>
               <systemProperty>
                 <name>fcrepo.dynamic.jms.port</name>
@@ -208,16 +205,17 @@
                 <goal>start</goal>
               </goals>
               <configuration>
+                <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
                 <httpConnector>
                   <port>${fcrepo.dynamic.test.port}</port>
                 </httpConnector>
                 <scanIntervalSeconds>0</scanIntervalSeconds>
                 <daemon>true</daemon>
                 <contextHandlers>
-                    <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
-                      <war>${project.build.directory}/fcrepo.war</war>
-                      <contextPath>/fcrepo</contextPath>
-                    </contextHandler>
+                  <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
+                    <war>${project.build.directory}/fcrepo.war</war>
+                    <contextPath>/fcrepo</contextPath>
+                  </contextHandler>
                 </contextHandlers>
               </configuration>
             </execution>

--- a/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
+++ b/fcrepo-reindexing/src/test/java/org/fcrepo/camel/reindexing/RouteTest.java
@@ -42,7 +42,7 @@ import org.junit.Test;
  * @author acoburn
  * @since 2015-05-22
  */
-public class RouteTest extends CamelBlueprintTestSupport {
+public class    RouteTest extends CamelBlueprintTestSupport {
 
     private static final String restPrefix = "/reindexing";
     private static final String reindexingStream = "broker:queue:foo";

--- a/fcrepo-reindexing/src/test/resources/jetty-test.xml
+++ b/fcrepo-reindexing/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-reindexing/src/test/resources/jetty-users.properties
+++ b/fcrepo-reindexing/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/fcrepo-serialization/pom.xml
+++ b/fcrepo-serialization/pom.xml
@@ -207,13 +207,14 @@
               <goal>start</goal>
             </goals>
             <configuration>
+              <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
               <httpConnector>
                 <port>${fcrepo.dynamic.test.port}</port>
               </httpConnector>
               <scanIntervalSeconds>0</scanIntervalSeconds>
               <daemon>true</daemon>
               <contextHandlers>
-                  <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                  <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                     <war>${project.build.directory}/fcrepo.war</war>
                     <contextPath>/fcrepo</contextPath>
                   </contextHandler>

--- a/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
+++ b/fcrepo-serialization/src/main/java/org/fcrepo/camel/serialization/SerializationRouter.java
@@ -51,6 +51,9 @@ public class SerializationRouter extends RouteBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SerializationRouter.class);
 
+    final String AUTH_PARAMS = "authUsername=" + System.getProperty("fcrepo.authUsername", "fedoraAdmin") +
+            "&authPassword=" + System.getProperty("fcrepo.authPassword", "fedoraAdmin");
+
     private static final String RESOURCE_DELETION = "http://fedora.info/definitions/v4/event#ResourceDeletion";
     private static final String DELETE = "https://www.w3.org/ns/activitystreams#Delete";
     private static final String REPOSITORY = "http://fedora.info/definitions/v4/repository#";
@@ -112,7 +115,7 @@ public class SerializationRouter extends RouteBuilder {
 
         from("direct:metadata")
             .routeId("FcrepoSerializationMetadataUpdater")
-            .to("fcrepo:localhost?accept={{serialization.mimeType}}")
+            .to("fcrepo:localhost?accept={{serialization.mimeType}}&" + AUTH_PARAMS)
             .log(INFO, LOGGER, "Serializing object ${headers[CamelFcrepoUri]}")
             .setHeader(FILE_NAME).simple("${headers[CamelSerializationPath]}.{{serialization.extension}}")
             .log(DEBUG, LOGGER, "filename is ${headers[CamelFileName]}")
@@ -122,10 +125,10 @@ public class SerializationRouter extends RouteBuilder {
             .routeId("FcrepoSerializationBinaryUpdater")
             .filter().simple("{{serialization.includeBinaries}} == 'true'")
             .to("fcrepo:localhost?preferInclude=PreferMinimalContainer" +
-                    "&accept=application/rdf+xml")
+                    "&accept=application/rdf+xml&" + AUTH_PARAMS)
             .filter().xpath(isBinaryResourceXPath, ns)
             .log(INFO, LOGGER, "Writing binary ${headers[CamelSerializationPath]}")
-            .to("fcrepo:localhost?metadata=false")
+            .to("fcrepo:localhost?metadata=false&" + AUTH_PARAMS)
             .setHeader(FILE_NAME).header(SERIALIZATION_PATH)
             .log(DEBUG, LOGGER, "header filename is: ${headers[CamelFileName]}")
             .to("file://{{serialization.binaries}}");

--- a/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/integration/RouteIT.java
+++ b/fcrepo-serialization/src/test/java/org/fcrepo/camel/serialization/integration/RouteIT.java
@@ -55,6 +55,9 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
     private static final String auditContainer = "/audit";
 
+    private static String FEDORA_USERNAME = "fedoraAdmin";
+    private static String FEDORA_PASSWORD = "fedoraAdmin";
+
     @EndpointInject(uri = "mock:result")
     protected MockEndpoint resultEndpoint;
 
@@ -66,7 +69,8 @@ public class RouteIT extends CamelBlueprintTestSupport {
 
     @Override
     protected void doPreSetup() throws Exception {
-        final FcrepoClient client = client().throwExceptionOnFailure().build();
+        final FcrepoClient client =  client().throwExceptionOnFailure()
+                .credentials(FEDORA_USERNAME, FEDORA_PASSWORD).build();
         final FcrepoResponse res = client.post(URI.create("http://localhost:" + FCREPO_PORT + "/fcrepo/rest"))
                 .body(loadResourceAsStream("indexable.ttl"), "text/turtle").perform();
         fullPath = res.getLocation().toString();

--- a/fcrepo-serialization/src/test/resources/event.json
+++ b/fcrepo-serialization/src/test/resources/event.json
@@ -1,36 +1,37 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/path/to/resource" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Create" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:43-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/path/to/resource" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "http://fedora.info/definitions/v4/event#ResourceCreation" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-serialization/src/test/resources/event_delete_resource.json
+++ b/fcrepo-serialization/src/test/resources/event_delete_resource.json
@@ -1,37 +1,37 @@
 {
-  "@context" : {
-    "prov" : "http://www.w3.org/ns/prov#" ,
-    "foaf" : "http://xmlns.com/foaf/0.1/" ,
-    "dcterms" : "http://purl.org/dc/terms/" ,
-    "xsd" : "http://www.w3.org/2001/XMLSchema#" ,
-
-    "type" : "@type" ,
-    "id" : "@id" ,
-
-    "atTime" : { "@id" : "prov:atTime", "@type" : "xsd:dateTime" } ,
-    "identifier" : { "@id" : "dcterms:identifier" , "@type" : "@id" } ,
-    "isPartOf" : { "@id" : "dcterms:isPartOf", "@type" : "@id" } ,
-    "name" : { "@id" : "foaf:name", "@type" : "xsd:string" } ,
-    "wasAttributedTo" : { "@id" : "prov:wasAttributedTo", "@type" : "@id" } ,
-    "wasGeneratedBy" : { "@id" : "prov:wasGeneratedBy", "@type" : "@id" }
-  } ,
-
-  "id" : "http://localhost/rest/auditions/1234" ,
+  "id": "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18",
   "type" : [
-    "http://www.w3.org/ns/prov#Entity" ,
-    "http://fedora.info/definitions/v4/repository#Resource" ,
-    "http://fedora.info/definitions/v4/repository#Container" ,
-    "http://example.org/CustomType" ] ,
-  "isPartOf" : "http://localhost/rest" ,
-  "wasGeneratedBy" : {
+    "http://www.w3.org/ns/prov#Activity" ,
+    "https://www.w3.org/ns/activitystreams#Delete" ],
+  "name": "delete resource",
+  "published": "2016-05-19T17:17:43-04:00Z",
+  "actor": [{
+    "type": ["Person"],
+    "id": "info:fedora/fedoraAdmin"
+  }, {
+    "type": ["Application"],
+    "name": "CLAW client/1.0"
+  }],
+
+  "object" : {
+    "id" : "http://localhost/rest/auditions/1234" ,
     "type" : [
-      "http://www.w3.org/ns/prov#Activity" ,
-      "https://www.w3.org/ns/activitystreams#Delete" ] ,
-    "identifier" : "urn:uuid:3c834a8f-5638-4412-aa4b-35ea80416a18" ,
-    "atTime" : "2016-05-19T17:17:39-04:00Z" } ,
-  "wasAttributedTo" : [
-    { "type" : "http://www.w3.org/ns/prov#Person" ,
-      "name" : "fedo raAdmin" },
-    { "type" : "http://www.w3.org/ns/prov#SoftwareAgent" ,
-      "name" : "CLAW client/1.0" } ]
+      "http://www.w3.org/ns/prov#Entity" ,
+      "http://fedora.info/definitions/v4/repository#Resource" ,
+      "http://fedora.info/definitions/v4/repository#Container" ,
+      "http://www.w3.org/ns/ldp#RDFSource",
+      "http://www.w3.org/ns/ldp#BasicContainer" ],
+    "isPartOf" : "http://localhost/rest"
+  },
+
+  "@context": ["https://www.w3.org/ns/activitystreams", {
+    "prov": "http://www.w3.org/ns/prov#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "type": "@type",
+    "id": "@id",
+    "isPartOf": {
+      "@id": "dcterms:isPartOf",
+      "@type": "@id"
+    }
+  }]
 }

--- a/fcrepo-serialization/src/test/resources/jetty-test.xml
+++ b/fcrepo-serialization/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-serialization/src/test/resources/jetty-users.properties
+++ b/fcrepo-serialization/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/fcrepo-service-activemq/pom.xml
+++ b/fcrepo-service-activemq/pom.xml
@@ -260,10 +260,6 @@
                 <value>${fcrepo.dynamic.reindexing.port}</value>
               </systemProperty>
               <systemProperty>
-                <name>fcrepo.dynamic.test.port</name>
-                <value>${fcrepo.dynamic.test.port}</value>
-              </systemProperty>
-              <systemProperty>
                 <name>fcrepo.dynamic.jms.port</name>
                 <value>${fcrepo.dynamic.jms.port}</value>
               </systemProperty>
@@ -290,13 +286,14 @@
                 <goal>start</goal>
               </goals>
               <configuration>
+                <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
                 <httpConnector>
                   <port>${fcrepo.dynamic.test.port}</port>
                 </httpConnector>
                 <scanIntervalSeconds>0</scanIntervalSeconds>
                 <daemon>true</daemon>
                 <contextHandlers>
-                    <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                    <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                       <war>${project.build.directory}/fcrepo.war</war>
                       <contextPath>/fcrepo</contextPath>
                     </contextHandler>

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/KarafIT.java
@@ -19,7 +19,6 @@ package org.fcrepo.camel.service.activemq;
 
 import static org.apache.camel.component.mock.MockEndpoint.assertIsSatisfied;
 import static org.apache.http.HttpStatus.SC_CREATED;
-import static org.apache.http.impl.client.HttpClientBuilder.create;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -46,7 +45,10 @@ import javax.inject.Inject;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
@@ -77,6 +79,9 @@ import org.slf4j.Logger;
 public class KarafIT {
 
     private static Logger LOGGER = getLogger(KarafIT.class);
+
+    private static String FEDORA_USERNAME = "fedoraAdmin";
+    private static String FEDORA_PASSWORD = "fedoraAdmin";
 
     @Inject
     protected FeaturesService featuresService;
@@ -149,7 +154,6 @@ public class KarafIT {
 
     @Test
     public void testQueuingService() throws Exception {
-        final CloseableHttpClient client = create().build();
         final String baseUrl = "http://localhost:" + System.getProperty("fcrepo.port") + "/fcrepo/rest";
         final CamelContext ctx = getOsgiService(CamelContext.class,
                 "(camel.context.name=FcrepoQueuingService)", 10000);
@@ -168,7 +172,10 @@ public class KarafIT {
     }
 
     private String post(final String url) {
-        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        final BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(FEDORA_USERNAME, FEDORA_PASSWORD));
+        final CloseableHttpClient httpclient = HttpClients.custom().setDefaultCredentialsProvider(provider).build();
+
         try {
             final HttpPost httppost = new HttpPost(url);
             final HttpResponse response = httpclient.execute(httppost);

--- a/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
+++ b/fcrepo-service-activemq/src/test/java/org/fcrepo/camel/service/activemq/RouteIT.java
@@ -31,7 +31,10 @@ import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.blueprint.CamelBlueprintTestSupport;
 import org.apache.camel.util.KeyValueHolder;
 import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
@@ -48,6 +51,9 @@ import org.slf4j.Logger;
 public class RouteIT extends CamelBlueprintTestSupport {
 
     private static final Logger LOGGER = getLogger(RouteIT.class);
+
+    private static String FEDORA_USERNAME = "fedoraAdmin";
+    private static String FEDORA_PASSWORD = "fedoraAdmin";
 
     @EndpointInject(uri = "mock:result")
     protected MockEndpoint resultEndpoint;
@@ -89,7 +95,9 @@ public class RouteIT extends CamelBlueprintTestSupport {
     }
 
     private String post(final String url) {
-        final CloseableHttpClient httpclient = HttpClients.createDefault();
+        final BasicCredentialsProvider provider = new BasicCredentialsProvider();
+        provider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(FEDORA_USERNAME, FEDORA_PASSWORD));
+        final CloseableHttpClient httpclient = HttpClients.custom().setDefaultCredentialsProvider(provider).build();
         try {
             final HttpPost httppost = new HttpPost(url);
             final HttpResponse response = httpclient.execute(httppost);

--- a/fcrepo-service-activemq/src/test/resources/jetty-test.xml
+++ b/fcrepo-service-activemq/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-service-activemq/src/test/resources/jetty-users.properties
+++ b/fcrepo-service-activemq/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/fcrepo-service-camel/pom.xml
+++ b/fcrepo-service-camel/pom.xml
@@ -225,10 +225,6 @@
                 <value>${fcrepo.dynamic.reindexing.port}</value>
               </systemProperty>
               <systemProperty>
-                <name>fcrepo.dynamic.test.port</name>
-                <value>${fcrepo.dynamic.test.port}</value>
-              </systemProperty>
-              <systemProperty>
                 <name>fcrepo.dynamic.jms.port</name>
                 <value>${fcrepo.dynamic.jms.port}</value>
               </systemProperty>
@@ -255,13 +251,14 @@
                 <goal>start</goal>
               </goals>
               <configuration>
+                <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
                 <httpConnector>
                   <port>${fcrepo.dynamic.test.port}</port>
                 </httpConnector>
                 <scanIntervalSeconds>0</scanIntervalSeconds>
                 <daemon>true</daemon>
                 <contextHandlers>
-                    <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                    <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                       <war>${project.build.directory}/fcrepo.war</war>
                       <contextPath>/fcrepo</contextPath>
                     </contextHandler>

--- a/fcrepo-service-camel/src/test/resources/jetty-test.xml
+++ b/fcrepo-service-camel/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/fcrepo-service-camel/src/test/resources/jetty-users.properties
+++ b/fcrepo-service-camel/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.6.0</version>
+    <version>4.7.5</version>
   </parent>
 
   <groupId>org.fcrepo.camel</groupId>
@@ -35,28 +35,28 @@
     <camel.version.range>[2.18,3)</camel.version.range>
 
     <!-- dependencies -->
-    <activemq.version>5.14.1</activemq.version>
-    <camel.version>2.18.0</camel.version>
-    <commons.lang3.version>3.4</commons.lang3.version>
+    <activemq.version>5.15.5</activemq.version>
+    <camel.version>2.18.2</camel.version>
+    <commons.lang3.version>3.7</commons.lang3.version>
     <jackson2.version>2.7.3</jackson2.version>
     <jena.version>3.1.1</jena.version>
     <logback.version>1.1.7</logback.version>
     <marmotta.version>3.3.0</marmotta.version>
     <slf4j.version>1.7.20</slf4j.version>
     <spring.version>4.2.5.RELEASE</spring.version>
-    <fcrepo.version>4.7.0</fcrepo.version>
-    <fcrepo-java-client.version>0.2.1</fcrepo-java-client.version>
-    <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
+    <fcrepo.version>5.0.1</fcrepo.version>
+    <fcrepo-java-client.version>0.4.0</fcrepo-java-client.version>
+    <fcrepo-camel.version>4.6.0-SNAPSHOT</fcrepo-camel.version>
     <woodstox.version>4.4.1</woodstox.version>
     <!-- testing -->
     <awaitility.version>1.7.0</awaitility.version>
-    <commons.codec.version>1.10</commons.codec.version>
-    <commons.io.version>2.4</commons.io.version>
+    <commons.codec.version>1.11</commons.codec.version>
+    <commons.io.version>2.6</commons.io.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <grizzly.version>2.3.16</grizzly.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <httpclient.version>4.3.6</httpclient.version>
-    <httpcore.version>4.4.6</httpcore.version>
+    <httpclient.version>4.5.6</httpclient.version>
+    <httpcore.version>4.4.10</httpcore.version>
     <hk2.version>2.3.0</hk2.version>
     <jena.fuseki.version>2.4.1</jena.fuseki.version>
     <jersey.version>2.22.2</jersey.version>
@@ -67,7 +67,8 @@
     <!-- osgi -->
     <osgi.import.packages>*</osgi.import.packages>
     <!-- plugins -->
-    <jetty.plugin.version>9.2.6.v20141205</jetty.plugin.version>
+    <jetty.plugin.version>9.3.25.v20180904</jetty.plugin.version>
+    <jetty.users.file>${project.build.directory}/test-classes/jetty-users.properties</jetty.users.file>
     <paxexam.plugin.version>1.2.4</paxexam.plugin.version>
   </properties>
 
@@ -195,11 +196,6 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons.io.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.fcrepo</groupId>
-        <artifactId>fcrepo-audit</artifactId>
-        <version>${fcrepo.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -443,6 +439,13 @@
 
   <build>
     <defaultGoal>install</defaultGoal>
+
+    <testResources>
+      <testResource>
+        <filtering>true</filtering>
+          <directory>src/test/resources</directory>
+      </testResource>
+    </testResources>
 
     <pluginManagement>
       <plugins>

--- a/toolbox-features/pom.xml
+++ b/toolbox-features/pom.xml
@@ -248,11 +248,11 @@
             <portName>fcrepo.dynamic.test.port</portName>
             <portName>fcrepo.dynamic.jms.port</portName>
             <portName>fcrepo.dynamic.stomp.port</portName>
+            <portName>jetty.dynamic.stop.port</portName>
             <portName>fcrepo.dynamic.reindexing.port</portName>
             <portName>karaf.rmiRegistry.port</portName>
             <portName>karaf.rmiServer.port</portName>
             <portName>karaf.ssh.port</portName>
-            <portName>jetty.dynamic.stop.port</portName>
           </portNames>
         </configuration>
         <executions>
@@ -330,10 +330,6 @@
               <value>${fcrepo.dynamic.stomp.port}</value>
             </systemProperty>
             <systemProperty>
-              <name>fcrepo.dynamic.test.port</name>
-              <value>${fcrepo.dynamic.test.port}</value>
-            </systemProperty>
-            <systemProperty>
               <name>fcrepo.modeshape.configuration</name>
               <value>classpath:/config/file-simple/repository.json</value>
             </systemProperty>
@@ -352,13 +348,14 @@
               <goal>start</goal>
             </goals>
             <configuration>
+              <jettyXml>${project.build.directory}/test-classes/jetty-test.xml</jettyXml>
               <httpConnector>
                 <port>${fcrepo.dynamic.test.port}</port>
               </httpConnector>
               <scanIntervalSeconds>0</scanIntervalSeconds>
               <daemon>true</daemon>
               <contextHandlers>
-                <contextHandler implementation="org.eclipse.jetty.webapp.WebAppContext">
+                <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">
                   <war>${project.build.directory}/fcrepo.war</war>
                   <contextPath>/fcrepo</contextPath>
                 </contextHandler>

--- a/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
+++ b/toolbox-features/src/test/java/org/fcrepo/camel/karaf/KarafIT.java
@@ -148,6 +148,9 @@ public class KarafIT {
                     "data/tmp/descriptions"),
             editConfigurationFilePut("etc/org.fcrepo.camel.reindexing.cfg", "rest.port", reindexingPort),
             editConfigurationFilePut("etc/org.fcrepo.camel.service.cfg", "fcrepo.baseUrl", fcrepoBaseUrl),
+            editConfigurationFilePut("etc/org.fcrepo.camel.service.cfg", "fcrepo.authUsername", "fedoraAdmin"),
+            editConfigurationFilePut("etc/org.fcrepo.camel.service.cfg", "fcrepo.authPassword", "fedoraAdmin"),
+
             editConfigurationFilePut("etc/org.fcrepo.camel.service.activemq.cfg", "jms.brokerUrl",
                     "tcp://localhost:" + jmsPort),
             editConfigurationFilePut("etc/org.ops4j.pax.logging.cfg",

--- a/toolbox-features/src/test/resources/jetty-test.xml
+++ b/toolbox-features/src/test/resources/jetty-test.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<!-- =============================================================== -->
+<!-- Documentation of this file format can be found at:              -->
+<!-- http://wiki.eclipse.org/Jetty/Reference/jetty.xml_syntax        -->
+<!--                                                                 -->
+<!-- Additional configuration files are available in $JETTY_HOME/etc -->
+<!-- and can be mixed in. See start.ini file for the default         -->
+<!-- configuration files.                                            -->
+<!--                                                                 -->
+<!-- For a description of the configuration mechanism, see the       -->
+<!-- output of:                                                      -->
+<!--   java -jar start.jar -?                                        -->
+<!-- =============================================================== -->
+
+<!-- =============================================================== -->
+<!-- Configure a Jetty Server instance with an ID "Server"           -->
+<!-- Other configuration files may also configure the "Server"       -->
+<!-- ID, in which case they are adding configuration to the same     -->
+<!-- instance.  If other configuration have a different ID, they     -->
+<!-- will create and configure another instance of Jetty.            -->
+<!-- Consult the javadoc of o.e.j.server.Server for all              -->
+<!-- configuration that may be set here.                             -->
+<!-- =============================================================== -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.security.HashLoginService">
+          <Set name="name">fcrepo</Set>
+          <Set name="config"><SystemProperty name="jetty-users" default="${jetty.users.file}"/></Set>
+        </New>
+      </Arg>
+    </Call>
+
+    <Set name="connectors">
+      <Array type="org.eclipse.jetty.server.Connector">
+        <Item>
+          <New class="org.eclipse.jetty.server.ServerConnector">
+            <Arg><Ref refid="Server"/></Arg>
+            <Set name="port" type="int"><SystemProperty name="fcrepo.dynamic.test.port" default="8080"/></Set>
+            <Set name="idleTimeout">60000</Set>
+          </New>
+        </Item>
+      </Array>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- Configure the Server Thread Pool.                           -->
+    <!-- The server holds a common thread pool which is used by      -->
+    <!-- default as the executor used by all connectors and servlet  -->
+    <!-- dispatches.                                                 -->
+    <!--                                                             -->
+    <!-- Configuring a fixed thread pool is vital to controlling the -->
+    <!-- maximal memory footprint of the server and is a key tuning  -->
+    <!-- parameter for tuning.  In an application that rarely blocks -->
+    <!-- then maximal threads may be close to the number of 5*CPUs.  -->
+    <!-- In an application that frequently blocks, then maximal      -->
+    <!-- threads should be set as high as possible given the memory  -->
+    <!-- available.                                                  -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.util.thread.QueuedThreadPool   -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <!-- uncomment to change type of threadpool
+    <Arg name="threadpool"><New id="threadpool" class="org.eclipse.jetty.util.thread.QueuedThreadPool"/></Arg>
+    -->
+    <Get name="ThreadPool">
+      <Set name="minThreads" type="int"><Property name="jetty.threadPool.minThreads" deprecated="threads.min" default="10"/></Set>
+      <Set name="maxThreads" type="int"><Property name="jetty.threadPool.maxThreads" deprecated="threads.max" default="200"/></Set>
+      <Set name="idleTimeout" type="int"><Property name="jetty.threadPool.idleTimeout" deprecated="threads.timeout" default="60000"/></Set>
+      <Set name="detailedDump">false</Set>
+    </Get>
+
+    <!-- =========================================================== -->
+    <!-- Add shared Scheduler instance                               -->
+    <!-- =========================================================== -->
+    <Call name="addBean">
+      <Arg>
+        <New class="org.eclipse.jetty.util.thread.ScheduledExecutorScheduler"/>
+      </Arg>
+    </Call>
+
+    <!-- =========================================================== -->
+    <!-- Http Configuration.                                         -->
+    <!-- This is a common configuration instance used by all         -->
+    <!-- connectors that can carry HTTP semantics (HTTP, HTTPS, etc.)-->
+    <!-- It configures the non wire protocol aspects of the HTTP     -->
+    <!-- semantic.                                                   -->
+    <!--                                                             -->
+    <!-- This configuration is only defined here and is used by      -->
+    <!-- reference from other XML files such as jetty-http.xml,      -->
+    <!-- jetty-https.xml and other configuration files which         -->
+    <!-- instantiate the connectors.                                 -->
+    <!--                                                             -->
+    <!-- Consult the javadoc of o.e.j.server.HttpConfiguration       -->
+    <!-- for all configuration that may be set here.                 -->
+    <!-- =========================================================== -->
+    <New id="httpConfig" class="org.eclipse.jetty.server.HttpConfiguration">
+      <Set name="secureScheme"><Property name="jetty.httpConfig.secureScheme" default="https" /></Set>
+      <Set name="securePort"><Property name="jetty.httpConfig.securePort" deprecated="jetty.secure.port" default="8443" /></Set>
+      <Set name="outputBufferSize"><Property name="jetty.httpConfig.outputBufferSize" deprecated="jetty.output.buffer.size" default="32768" /></Set>
+      <Set name="outputAggregationSize"><Property name="jetty.httpConfig.outputAggregationSize" deprecated="jetty.output.aggregation.size" default="8192" /></Set>
+      <Set name="requestHeaderSize"><Property name="jetty.httpConfig.requestHeaderSize" deprecated="jetty.request.header.size" default="8192" /></Set>
+      <Set name="responseHeaderSize"><Property name="jetty.httpConfig.responseHeaderSize" deprecated="jetty.response.header.size" default="8192" /></Set>
+      <Set name="sendServerVersion"><Property name="jetty.httpConfig.sendServerVersion" deprecated="jetty.send.server.version" default="true" /></Set>
+      <Set name="sendDateHeader"><Property name="jetty.httpConfig.sendDateHeader" deprecated="jetty.send.date.header" default="false" /></Set>
+      <Set name="headerCacheSize"><Property name="jetty.httpConfig.headerCacheSize" default="512" /></Set>
+      <Set name="delayDispatchUntilContent"><Property name="jetty.httpConfig.delayDispatchUntilContent" deprecated="jetty.delayDispatchUntilContent" default="true"/></Set>
+      <!-- Uncomment to enable handling of X-Forwarded- style headers
+      <Call name="addCustomizer">
+        <Arg><New class="org.eclipse.jetty.server.ForwardedRequestCustomizer"/></Arg>
+      </Call>
+      -->
+    </New>
+
+    <!-- =========================================================== -->
+    <!-- Set the default handler structure for the Server            -->
+    <!-- A handler collection is used to pass received requests to   -->
+    <!-- both the ContextHandlerCollection, which selects the next   -->
+    <!-- handler by context path and virtual host, and the           -->
+    <!-- DefaultHandler, which handles any requests not handled by   -->
+    <!-- the context handlers.                                       -->
+    <!-- Other handlers may be added to the "Handlers" collection,   -->
+    <!-- for example the jetty-requestlog.xml file adds the          -->
+    <!-- RequestLogHandler after the default handler                 -->
+    <!-- =========================================================== -->
+    <Set name="handler">
+      <New id="Handlers" class="org.eclipse.jetty.server.handler.HandlerCollection">
+        <Set name="handlers">
+         <Array type="org.eclipse.jetty.server.Handler">
+           <Item>
+             <New id="Contexts" class="org.eclipse.jetty.server.handler.ContextHandlerCollection"/>
+           </Item>
+           <Item>
+             <New id="DefaultHandler" class="org.eclipse.jetty.server.handler.DefaultHandler"/>
+           </Item>
+         </Array>
+        </Set>
+      </New>
+    </Set>
+
+    <!-- =========================================================== -->
+    <!-- extra server options                                        -->
+    <!-- =========================================================== -->
+    <Set name="stopAtShutdown"><Property name="jetty.server.stopAtShutdown" default="true"/></Set>
+    <Set name="stopTimeout">5000</Set>
+    <Set name="dumpAfterStart"><Property name="jetty.server.dumpAfterStart" deprecated="jetty.dump.start" default="false"/></Set>
+    <Set name="dumpBeforeStop"><Property name="jetty.server.dumpBeforeStop" deprecated="jetty.dump.stop" default="false"/></Set>
+
+</Configure>

--- a/toolbox-features/src/test/resources/jetty-users.properties
+++ b/toolbox-features/src/test/resources/jetty-users.properties
@@ -1,0 +1,3 @@
+testuser: testpass,fedoraUser
+testuser2: testpass,fedoraUser
+fedoraAdmin: fedoraAdmin,fedoraAdmin


### PR DESCRIPTION
**Updates fcrepo-camel-toolbox to work with Fedora 5.x.**
* * *

**JIRA Ticket**: https://jira.duraspace.org/browse/FCREPO-2787

* Other Relevant Links (Mailing list discussion, related pull requests, etc.)

# What does this Pull Request do?

1. Adds support for authentication to the integration tests.
2. Fixes all broken unit tests.
3. Updates fcrepo 5 and related dependencies.


# What's new?
Authentication support for the integration tests, both in the test code as well as the jetty test server, is the main change. Otherwise just fcrepo4 and fcrepo-java-client dependency updates.

# How should this be tested?
This PR ensures that the unit and integration tests are passing.   Be sure to build the latest fcrepo-camel locally before building this PR.   I have not done any hands on testing at this point:  this PR simply ensures that all the tests are passing.

# Interested parties
@peichman-umd, @awoods, @birkland 
