### PR TITLE
Ensures that the fcrepo-java-client dependency is resolveable.

### DIFF
--- a/toolbox-features/pom.xml
+++ b/toolbox-features/pom.xml
@@ -155,7 +155,6 @@
     <dependency>
       <groupId>org.fcrepo.client</groupId>
       <artifactId>fcrepo-java-client</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
When running in fcrepo4-vagrant,  I found that karaf was complaining about a missing fcrepo-java-client dependency.  This change has been tested in vagrant (by manually copying my .m2/repository/org/fcrepo/camel to my vagrant instance after a `mvn clean install`).